### PR TITLE
Update uboot to 2023.10

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,22 +41,22 @@
         "SoQuartzModelA" = {
           uBoot = (uBoot system).uBootSoQuartzModelA;
           kernel = (kernel system).linux_6_5_rockchip;
-          extraModules = [ self.nixosModules.dtOverlayPCIeFix noZFS ];
+          extraModules = [  noZFS ];
         };
         "SoQuartzCM4"    = {
           uBoot = (uBoot system).uBootSoQuartzCM4IO;
           kernel = (kernel system).linux_6_5_rockchip;
-          extraModules = [ self.nixosModules.dtOverlayPCIeFix noZFS ];
+          extraModules = [  noZFS ];
         };
         "SoQuartzBlade"  = {
           uBoot = (uBoot system).uBootSoQuartzBlade;
           kernel = (kernel system).linux_6_5_rockchip;
-          extraModules = [ self.nixosModules.dtOverlayPCIeFix noZFS ];
+          extraModules = [  noZFS ];
         };
         "PineTab2"      = {
           uBoot = (uBoot system).uBootPineTab2;
           kernel = (kernel system).linux_6_5_pinetab;
-          extraModules = [ self.nixosModules.dtOverlayPCIeFix noZFS ];
+          extraModules = [  noZFS ];
         };
         "Rock64"      = { uBoot = (pkgs system).ubootRock64;      kernel = (kernel system).linux_6_1_rockchip; extraModules = []; };
         "RockPro64"   = { uBoot = (pkgs system).ubootRockPro64;   kernel = (kernel system).linux_6_1_rockchip; extraModules = []; };

--- a/flake.nix
+++ b/flake.nix
@@ -41,17 +41,17 @@
         "SoQuartzModelA" = {
           uBoot = (uBoot system).uBootSoQuartzModelA;
           kernel = (kernel system).linux_6_5_rockchip;
-          extraModules = [  noZFS ];
+          extraModules = [ noZFS ];
         };
         "SoQuartzCM4"    = {
           uBoot = (uBoot system).uBootSoQuartzCM4IO;
           kernel = (kernel system).linux_6_5_rockchip;
-          extraModules = [  noZFS ];
+          extraModules = [ noZFS ];
         };
         "SoQuartzBlade"  = {
           uBoot = (uBoot system).uBootSoQuartzBlade;
           kernel = (kernel system).linux_6_5_rockchip;
-          extraModules = [  noZFS ];
+          extraModules = [ noZFS ];
         };
         "PineTab2"      = {
           uBoot = (uBoot system).uBootPineTab2;

--- a/modules/sd-card/sd-image-rockchip.nix
+++ b/modules/sd-card/sd-image-rockchip.nix
@@ -22,7 +22,7 @@
   config.sdImage = let
     uBoot = config.rockchip.uBoot;
 
-    idbloaderOffset = 64; # 0x40
+    uBootBinOffset = 64; # 0x40
     ubootOffset = 16384; # 0x4000
     # 1.7Mb at the moment; use very safe security margin of 8MB.
     ubootSize = 16384; # 8mb
@@ -41,8 +41,7 @@
     # Overwrite firmware partition with u-boot bootloader
     postBuildCommands = ''
       sfdisk --part-type "$img" 1 DA # mark partition as "Non-FS data"
-      dd if="${uBoot}/idbloader.img" of="$img" conv=fsync,notrunc bs=16M seek=${toString (idbloaderOffset * 512)} iflag=direct,count_bytes,skip_bytes oflag=direct,seek_bytes
-      dd if="${uBoot}/u-boot.itb" of="$img" conv=fsync,notrunc bs=16M seek=${toString (ubootOffset * 512)} iflag=direct,count_bytes,skip_bytes oflag=direct,seek_bytes
+      dd if="${uBoot}/u-boot-rockchip.bin" of="$img" conv=fsync,notrunc bs=16M seek=${toString (uBootBinOffset * 512)} iflag=direct,count_bytes,skip_bytes oflag=direct,seek_bytes
       sfdisk -d "$img"
     '';
     # Fill the root partition with this nix configuration in /etc/nixos

--- a/modules/sd-card/sd-image-rockchip.nix
+++ b/modules/sd-card/sd-image-rockchip.nix
@@ -22,7 +22,7 @@
   config.sdImage = let
     uBoot = config.rockchip.uBoot;
 
-    uBootBinOffset = 64; # 0x40
+    idbloaderOffset = 64; # 0x40
     ubootOffset = 16384; # 0x4000
     # 1.7Mb at the moment; use very safe security margin of 8MB.
     ubootSize = 16384; # 8mb
@@ -41,7 +41,8 @@
     # Overwrite firmware partition with u-boot bootloader
     postBuildCommands = ''
       sfdisk --part-type "$img" 1 DA # mark partition as "Non-FS data"
-      dd if="${uBoot}/u-boot-rockchip.bin" of="$img" conv=fsync,notrunc bs=16M seek=${toString (uBootBinOffset * 512)} iflag=direct,count_bytes,skip_bytes oflag=direct,seek_bytes
+      # u-boot-rockchip.bin contains both idbloader and uboot
+      dd if="${uBoot}/u-boot-rockchip.bin" of="$img" conv=fsync,notrunc bs=16M seek=${toString (idbloaderOffset * 512)} iflag=direct,count_bytes,skip_bytes oflag=direct,seek_bytes
       sfdisk -d "$img"
     '';
     # Fill the root partition with this nix configuration in /etc/nixos

--- a/pkgs/uboot-rockchip.nix
+++ b/pkgs/uboot-rockchip.nix
@@ -15,7 +15,7 @@ let
       rev = "v2023.10";
       sha256 = "f0xDGxTatRtCxwuDnmsqFLtYLIyjA5xzyQcwfOy3zEM=";
     };
-    version = "v2023.10-19b77d3d239";
+    version = "v2023.10-0bc339ffa6f";
   in buildUBoot {
     src = src;
     version = version;

--- a/pkgs/uboot-rockchip.nix
+++ b/pkgs/uboot-rockchip.nix
@@ -15,7 +15,7 @@ let
       rev = "v2023.10";
       sha256 = "f0xDGxTatRtCxwuDnmsqFLtYLIyjA5xzyQcwfOy3zEM=";
     };
-    version = "v2023.10-4459ed60cb1";
+    version = "v2023.10-69-g0bc339ffa6"; # git describe --long
   in buildUBoot {
     src = src;
     version = version;

--- a/pkgs/uboot-rockchip.nix
+++ b/pkgs/uboot-rockchip.nix
@@ -6,27 +6,27 @@ let
     rkbin = fetchFromGitHub {
       owner = "rockchip-linux";
       repo = "rkbin";
-      rev = "d6ccfe401ca84a98ca3b85c12b9554a1a43a166c";
-      sha256 = "Wp2nP0fszFhXz8QJ9MjG+YdMmz7/OJp3oFHEOmfyIyE=";
+      rev = "b4558da0860ca48bf1a571dd33ccba580b9abe23";
+      sha256 = "KUZQaQ+IZ0OynawlYGW99QGAOmOrGt2CZidI3NTxFw8=";
     };
     src = fetchFromGitHub {
       owner = "u-boot";
       repo = "u-boot";
-      rev = "v2023.07-rc4";
-      sha256 = "0FT8r9P6VeV/b5pv8x6wOyjwpoNjZZ6AmVZLatAU1Co=";
+      rev = "v2023.10";
+      sha256 = "f0xDGxTatRtCxwuDnmsqFLtYLIyjA5xzyQcwfOy3zEM=";
     };
-    version = "v2023.07-rc4-20-19b77d3d239";
+    version = "v2023.10-19b77d3d239";
   in buildUBoot {
     src = src;
     version = version;
     defconfig = defconfig;
-    filesToInstall = [ "u-boot.itb" "idbloader.img"];
+    filesToInstall = [ "u-boot-rockchip.bin" ];
 
     patches = [
       (fetchpatch {
         name = "quartz64.patch";
-        url = "https://github.com/Kwiboo/u-boot-rockchip/compare/19b77d3d23966a0d6dbb3c86187765f11100fb6f...2e0e11b8e65c48a43270f4ec4a88b74c8a83e269.diff";
-        sha256 = "msNkAOFLfu0SX1ePPGpeQ3B+sfqDbpTjxBgT3uJw4kE=";
+        url = "https://github.com/Kwiboo/u-boot-rockchip/compare/4459ed60cb1e0562bc5b40405e2b4b9bbf766d57...0bc339ffa6f804d51c5c5292d8ff69c4d79614d3.diff";
+        sha256 = "ui77Nm3IS6PUzaMagqyyZDitklot8MmeYg27mVPV7Pc=";
       })
     ];
 
@@ -53,8 +53,12 @@ let
       which # for scripts/dtc-version.sh
     ];
 
-    BL31 = (rkbin + "/bin/rk35/rk3568_bl31_v1.42.elf");
-    ROCKCHIP_TPL = (rkbin + "/bin/rk35/rk3566_ddr_1056MHz_v1.16.bin");
+    makeFlags = [
+      "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+    ];
+
+    BL31 = (rkbin + "/bin/rk35/rk3568_bl31_v1.43.elf");
+    ROCKCHIP_TPL = (rkbin + "/bin/rk35/rk3566_ddr_1056MHz_v1.18.bin");
 
     extraMeta = {
       platforms = [ "aarch64-linux" ];

--- a/pkgs/uboot-rockchip.nix
+++ b/pkgs/uboot-rockchip.nix
@@ -15,7 +15,7 @@ let
       rev = "v2023.10";
       sha256 = "f0xDGxTatRtCxwuDnmsqFLtYLIyjA5xzyQcwfOy3zEM=";
     };
-    version = "v2023.10-0bc339ffa6f";
+    version = "v2023.10-4459ed60cb1";
   in buildUBoot {
     src = src;
     version = version;


### PR DESCRIPTION
This also switches to using `u-boot-rockchip.bin` as the output file, rather than the two split files in the previous version

the main difference in the build process is overriding the make flags to remove `DTC=dtc`, which was causing make failures.