### PR TITLE
Update kernel to 6.6, NixOS to 23.11, add patches for rk3399 and rk3328 uboots

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -17,8 +17,8 @@ jobs:
       matrix:
         package:
         - kernel_linux_6_1_rockchip
-        - kernel_linux_6_5_rockchip
-        - kernel_linux_6_5_pinetab
+        - kernel_linux_6_6_rockchip
+        - kernel_linux_6_6_pinetab
         - uBootPineTab2
         - uBootQuartz64A
         - uBootQuartz64B

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -19,6 +19,10 @@ jobs:
         - kernel_linux_6_1_rockchip
         - kernel_linux_6_6_rockchip
         - kernel_linux_6_6_pinetab
+        - uBootRock64
+        - uBootRockPro64
+        - uBootPinebookPro
+        - uBootROCPCRK3399
         - uBootPineTab2
         - uBootQuartz64A
         - uBootQuartz64B

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -9,8 +9,8 @@ jobs:
       matrix:
         package:
         - kernel_linux_6_1_rockchip
-        - kernel_linux_6_5_rockchip
-        - kernel_linux_6_5_pinetab
+        - kernel_linux_6_6_rockchip
+        - kernel_linux_6_6_pinetab
         - uBootPineTab2
         - uBootQuartz64A
         - uBootQuartz64B

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -11,6 +11,10 @@ jobs:
         - kernel_linux_6_1_rockchip
         - kernel_linux_6_6_rockchip
         - kernel_linux_6_6_pinetab
+        - uBootRock64
+        - uBootRockPro64
+        - uBootPinebookPro
+        - uBootROCPCRK3399
         - uBootPineTab2
         - uBootQuartz64A
         - uBootQuartz64B

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgsStable": {
       "locked": {
-        "lastModified": 1703351344,
-        "narHash": "sha256-9FEelzftkE9UaJ5nqxidaJJPEhe9TPhbypLHmc2Mysc=",
+        "lastModified": 1703200384,
+        "narHash": "sha256-q5j06XOsy0qHOarsYPfZYJPWbTbc8sryRxianlEPJN0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7790e078f8979a9fcd543f9a47427eeaba38f268",
+        "rev": "0b3d618173114c64ab666f557504d6982665d328",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Build NixOS images for rockchip based single computer boards";
 
   inputs = {
-    nixpkgsStable.url   = "github:NixOS/nixpkgs/nixos-23.05";
+    nixpkgsStable.url   = "github:NixOS/nixpkgs/nixos-23.11";
     nixpkgsUnstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     utils.url           = "github:numtide/flake-utils";
   };
@@ -40,28 +40,28 @@
         };
         "SoQuartzModelA" = {
           uBoot = (uBoot system).uBootSoQuartzModelA;
-          kernel = (kernel system).linux_6_5_rockchip;
+          kernel = (kernel system).linux_6_6_rockchip;
           extraModules = [ noZFS ];
         };
         "SoQuartzCM4"    = {
           uBoot = (uBoot system).uBootSoQuartzCM4IO;
-          kernel = (kernel system).linux_6_5_rockchip;
+          kernel = (kernel system).linux_6_6_rockchip;
           extraModules = [ noZFS ];
         };
         "SoQuartzBlade"  = {
           uBoot = (uBoot system).uBootSoQuartzBlade;
-          kernel = (kernel system).linux_6_5_rockchip;
+          kernel = (kernel system).linux_6_6_rockchip;
           extraModules = [ noZFS ];
         };
         "PineTab2"      = {
           uBoot = (uBoot system).uBootPineTab2;
-          kernel = (kernel system).linux_6_5_pinetab;
+          kernel = (kernel system).linux_6_6_pinetab;
           extraModules = [  noZFS ];
         };
-        "Rock64"      = { uBoot = (pkgs system).ubootRock64;      kernel = (kernel system).linux_6_1_rockchip; extraModules = []; };
-        "RockPro64"   = { uBoot = (pkgs system).ubootRockPro64;   kernel = (kernel system).linux_6_1_rockchip; extraModules = []; };
-        "ROCPCRK3399" = { uBoot = (pkgs system).ubootROCPCRK3399; kernel = (kernel system).linux_6_1_rockchip; extraModules = []; };
-        "PinebookPro" = { uBoot = (pkgs system).ubootPinebookPro; kernel = (kernel system).linux_6_1_rockchip; extraModules = []; };
+        "Rock64"      = { uBoot = (uBoot system).ubootRock64;      kernel = (kernel system).linux_6_1_rockchip; extraModules = []; };
+        "RockPro64"   = { uBoot = (uBoot system).ubootRockPro64;   kernel = (kernel system).linux_6_1_rockchip; extraModules = []; };
+        "ROCPCRK3399" = { uBoot = (uBoot system).ubootROCPCRK3399; kernel = (kernel system).linux_6_1_rockchip; extraModules = []; };
+        "PinebookPro" = { uBoot = (uBoot system).ubootPinebookPro; kernel = (kernel system).linux_6_1_rockchip; extraModules = []; };
       };
 
       osConfigs = system: builtins.mapAttrs
@@ -93,12 +93,16 @@
         {
           packages = (images system) // {
             kernel_linux_6_1_rockchip = (kernel system).linux_6_1_rockchip.kernel;
-            kernel_linux_6_5_rockchip = (kernel system).linux_6_5_rockchip.kernel;
-            kernel_linux_6_5_pinetab  = (kernel system).linux_6_5_pinetab.kernel;
+            kernel_linux_6_6_rockchip = (kernel system).linux_6_6_rockchip.kernel;
+            kernel_linux_6_6_pinetab  = (kernel system).linux_6_6_pinetab.kernel;
 
-            uBootQuartz64A = (uBoot system).uBootQuartz64A;
-            uBootQuartz64B = (uBoot system).uBootQuartz64B;
-            uBootPineTab2  = (uBoot system).uBootPineTab2;
+            uBootQuartz64A   = (uBoot system).uBootQuartz64A;
+            uBootQuartz64B   = (uBoot system).uBootQuartz64B;
+            uBootPineTab2    = (uBoot system).uBootPineTab2;
+            uBootPinebookPro = (uBoot system).uBootPinebookPro;
+            uBootRockPro64   = (uBoot system).uBootRockPro64;
+            uBootROCPCRK3399 = (uBoot system).uBootROCPCRK3399;
+            uBootRock64      = (uBoot system).uBootRock64;
 
             uBootSoQuartzModelA = (uBoot system).uBootSoQuartzModelA;
             uBootSoQuartzCM4IO  = (uBoot system).uBootSoQuartzCM4IO;

--- a/pkgs/linux-rockchip.nix
+++ b/pkgs/linux-rockchip.nix
@@ -43,19 +43,19 @@ with pkgs.linuxKernel;
   linux_6_1          = pkgs.linuxPackages_6_1;
   linux_6_1_rockchip = packagesFor (kernels.linux_6_1.override { structuredExtraConfig = kernelConfig; });
 
-  linux_6_5          = pkgs.linuxPackages_6_5;
-  linux_6_5_rockchip = packagesFor (kernels.linux_6_5.override { structuredExtraConfig = kernelConfig; });
+  linux_6_6          = pkgs.linuxPackages_6_6;
+  linux_6_6_rockchip = packagesFor (kernels.linux_6_6.override { structuredExtraConfig = kernelConfig; });
 
-  linux_6_5_pinetab  = packagesFor (kernels.linux_6_5.override {
+  linux_6_6_pinetab  = packagesFor (kernels.linux_6_6.override {
     argsOverride = {
       src = pkgs.fetchFromGitHub {
         owner = "dreemurrs-embedded";
         repo = "linux-pinetab2";
-        rev = "1148003fdea1f265c7bfef57f3bca9c8b29f62a1";
-        sha256 = "Liz2eMDjAz9EcwC8Gj3wI+xAuXP0qWb3Fq2u0t7VNDw=";
+        rev = "81e3aa387e0dcb349e0d3f3c05f2f62742f814d7";
+        sha256 = "kkO54FbexUuuvZNFDuTtFMokBgKrCZXTQDCzsSRZNDE=";
       };
-      version = "6.5.8-danctnix1";
-      modDirVersion = "6.5.8-danctnix1";
+      version = "6.6.8-danctnix1";
+      modDirVersion = "6.6.8-danctnix1";
     };
     structuredExtraConfig = kernelConfig;
   });

--- a/pkgs/ramdisk_addr_r.patch
+++ b/pkgs/ramdisk_addr_r.patch
@@ -1,0 +1,26 @@
+diff --git a/include/configs/rk3328_common.h b/include/configs/rk3328_common.h
+index e920ec7e5d..d7eebdf4b4 100644
+--- a/include/configs/rk3328_common.h
++++ b/include/configs/rk3328_common.h
+@@ -18,7 +18,7 @@
+ 	"pxefile_addr_r=0x00600000\0" \
+ 	"fdt_addr_r=0x01f00000\0" \
+ 	"kernel_addr_r=0x02080000\0" \
+-	"ramdisk_addr_r=0x06000000\0" \
++	"ramdisk_addr_r=0x0a200000\0" \
+ 	"kernel_comp_addr_r=0x08000000\0" \
+ 	"kernel_comp_size=0x2000000\0"
+ 
+diff --git a/include/configs/rk3399_common.h b/include/configs/rk3399_common.h
+index 96ba19c659..c90f7d8d60 100644
+--- a/include/configs/rk3399_common.h
++++ b/include/configs/rk3399_common.h
+@@ -39,7 +39,7 @@
+ 	"fdt_addr_r=0x01f00000\0" \
+ 	"fdtoverlay_addr_r=0x02000000\0" \
+ 	"kernel_addr_r=0x02080000\0" \
+-	"ramdisk_addr_r=0x06000000\0" \
++	"ramdisk_addr_r=0x0a200000\0" \
+ 	"kernel_comp_addr_r=0x08000000\0" \
+ 	"kernel_comp_size=0x2000000\0"
+ 

--- a/pkgs/uboot-rockchip.nix
+++ b/pkgs/uboot-rockchip.nix
@@ -1,14 +1,8 @@
 { pkgs, stdenv, lib, fetchpatch, fetchFromGitHub, buildUBoot, buildPackages }:
 
 let 
-  buildRK3566UBoot = defconfig: let
-    inherit defconfig;
-    rkbin = fetchFromGitHub {
-      owner = "rockchip-linux";
-      repo = "rkbin";
-      rev = "b4558da0860ca48bf1a571dd33ccba580b9abe23";
-      sha256 = "KUZQaQ+IZ0OynawlYGW99QGAOmOrGt2CZidI3NTxFw8=";
-    };
+  buildPatchedUBoot = { defconfig, BL31, ROCKCHIP_TPL ? "" }: let
+    inherit defconfig BL31 ROCKCHIP_TPL;
     src = fetchFromGitHub {
       owner = "u-boot";
       repo = "u-boot";
@@ -28,6 +22,7 @@ let
         url = "https://github.com/Kwiboo/u-boot-rockchip/compare/4459ed60cb1e0562bc5b40405e2b4b9bbf766d57...0bc339ffa6f804d51c5c5292d8ff69c4d79614d3.diff";
         sha256 = "ui77Nm3IS6PUzaMagqyyZDitklot8MmeYg27mVPV7Pc=";
       })
+      ./ramdisk_addr_r.patch
     ];
 
     buildInputs = with buildPackages; [
@@ -57,13 +52,34 @@ let
       "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
     ];
 
-    BL31 = (rkbin + "/bin/rk35/rk3568_bl31_v1.43.elf");
-    ROCKCHIP_TPL = (rkbin + "/bin/rk35/rk3566_ddr_1056MHz_v1.18.bin");
+    BL31 = BL31;
+    ROCKCHIP_TPL = ROCKCHIP_TPL;
 
     extraMeta = {
       platforms = [ "aarch64-linux" ];
       license = lib.licenses.unfreeRedistributableFirmware;
     };
+  };
+  buildRk3328UBoot = defconfig: buildPatchedUBoot {
+    inherit defconfig;
+    BL31 = "${pkgs.armTrustedFirmwareRK3328}/bl31.elf";
+  };
+  buildRK3399UBoot = defconfig: buildPatchedUBoot {
+    inherit defconfig;
+    BL31 = "${pkgs.armTrustedFirmwareRK3399}/bl31.elf";
+  };
+  buildRK3566UBoot = defconfig: let
+    rkbin = fetchFromGitHub {
+      owner = "rockchip-linux";
+      repo = "rkbin";
+      rev = "b4558da0860ca48bf1a571dd33ccba580b9abe23";
+      sha256 = "KUZQaQ+IZ0OynawlYGW99QGAOmOrGt2CZidI3NTxFw8=";
+    };
+  in
+  buildPatchedUBoot { 
+    inherit defconfig; 
+    BL31 = (rkbin + "/bin/rk35/rk3568_bl31_v1.43.elf");
+    ROCKCHIP_TPL = (rkbin + "/bin/rk35/rk3566_ddr_1056MHz_v1.18.bin");
   };
   buildRK3566UBoot_2022_04 = defconfig: let
     inherit defconfig;
@@ -112,6 +128,10 @@ in {
   uBootSoQuartzCM4IO  = buildRK3566UBoot "soquartz-cm4-rk3566_defconfig";
   uBootSoQuartzModelA = buildRK3566UBoot "soquartz-model-a-rk3566_defconfig";
   uBootPineTab2       = buildRK3566UBoot "pinetab2-rk3566_defconfig";
+  uBootPinebookPro    = buildRK3399UBoot "pinebook-pro-rk3399_defconfig";
+  uBootRockPro64      = buildRK3399UBoot "rockpro64-rk3399_defconfig";
+  uBootROCPCRK3399    = buildRK3399UBoot "roc-pc-rk3399_defconfig";
+  uBootRock64         = buildRk3328UBoot "rock64-rk3328_defconfig";
 
   uBootQuartz64A_2022_04 = buildRK3566UBoot_2022_04 "quartz64-a-rk3566_defconfig";
   uBootQuartz64B_2022_04 = buildRK3566UBoot_2022_04 "quartz64-b-rk3566_defconfig";


### PR DESCRIPTION
Tested on SoQuartz Blade, RockPro64, and Rock64. I needed to push the initrd address for rk3399 and rk3328 due to the size of the 6.6.8 kernel. I copied the new value from the rk335x config