### PR TITLE
Add linux 6.8 for pinetab, rockchip. Add bes2600 firmware & kernel config

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         package:
         - kernel_linux_6_6_rockchip.kernel
-        - kernel_linux_6_6_pinetab.kernel
+        - kernel_linux_6_8_pinetab.kernel
         - uBootRock64
         - uBootRockPro64
         - uBootPinebookPro

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -18,7 +18,8 @@ jobs:
         package:
         - kernel_linux_6_1_rockchip.kernel
         - kernel_linux_6_6_rockchip.kernel
-        - kernel_linux_6_6_pinetab.kernel
+        - kernel_linux_6_8_rockchip.kernel
+        - kernel_linux_6_8_pinetab.kernel
         - uBootRock64
         - uBootRockPro64
         - uBootPinebookPro

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgsStable": {
       "locked": {
-        "lastModified": 1706515015,
-        "narHash": "sha256-eFfY5A7wlYy3jD/75lx6IJRueg4noE+jowl0a8lIlVo=",
+        "lastModified": 1710951922,
+        "narHash": "sha256-FOOBJ3DQenLpTNdxMHR2CpGZmYuctb92gF0lpiirZ30=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f4a8d6d5324c327dcc2d863eb7f3cc06ad630df4",
+        "rev": "f091af045dff8347d66d186a62d42aceff159456",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "nixpkgsUnstable": {
       "locked": {
-        "lastModified": 1706371002,
-        "narHash": "sha256-dwuorKimqSYgyu8Cw6ncKhyQjUDOyuXoxDTVmAXq88s=",
+        "lastModified": 1711001935,
+        "narHash": "sha256-URtGpHue7HHZK0mrHnSf8wJ6OmMKYSsoLmJybrOLFSQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c002c6aa977ad22c60398daaa9be52f2203d0006",
+        "rev": "20f77aa09916374aa3141cbc605c955626762c9a",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,8 @@
         (pkgsUnstable system).callPackage ./pkgs/uboot-rockchip.nix { };
       kernel = system:
         (pkgsUnstable system).callPackage ./pkgs/linux-rockchip.nix { };
+      bes2600Firmware = system:
+        (pkgsUnstable system).callPackage ./pkgs/bes2600-firmware.nix { };
 
       # ZFS is broken on kernel from unstable.
       noZFS = {
@@ -36,6 +38,11 @@
             zfs = super.zfs.overrideAttrs (_: { meta.platforms = [ ]; });
           })
         ];
+      };
+
+      bes2600 = system: {
+        nixpkgs.config.allowUnfree = true;
+        hardware.firmware = [ (bes2600Firmware system) ];
       };
 
       boards = system: {
@@ -66,8 +73,8 @@
         };
         "PineTab2" = {
           uBoot = (uBoot system).uBootPineTab2;
-          kernel = (kernel system).linux_6_6_pinetab;
-          extraModules = [ noZFS ];
+          kernel = (kernel system).linux_6_8_pinetab;
+          extraModules = [ (bes2600 system) noZFS ];
         };
         "Rock64" = {
           uBoot = (uBoot system).uBootRock64;
@@ -127,7 +134,8 @@
       legacyPackages = {
         kernel_linux_6_1_rockchip = (kernel system).linux_6_1_rockchip;
         kernel_linux_6_6_rockchip = (kernel system).linux_6_6_rockchip;
-        kernel_linux_6_6_pinetab = (kernel system).linux_6_6_pinetab;
+        kernel_linux_6_8_rockchip = (kernel system).linux_6_8_rockchip;
+        kernel_linux_6_8_pinetab = (kernel system).linux_6_8_pinetab;
       };
       packages = (images system) // {
         uBootQuartz64A = (uBoot system).uBootQuartz64A;
@@ -141,6 +149,8 @@
         uBootSoQuartzModelA = (uBoot system).uBootSoQuartzModelA;
         uBootSoQuartzCM4IO = (uBoot system).uBootSoQuartzCM4IO;
         uBootSoQuartzBlade = (uBoot system).uBootSoQuartzBlade;
+
+        bes2600 = (bes2600Firmware system);
       };
       formatter = (import inputs.nixpkgsStable { inherit system; }).nixfmt;
     });

--- a/pkgs/bes2600-firmware.nix
+++ b/pkgs/bes2600-firmware.nix
@@ -1,0 +1,24 @@
+{ fetchFromGitLab, lib, stdenv }:
+
+stdenv.mkDerivation {
+  pname = "bes2600-firmware";
+  version = "";
+
+  src = fetchFromGitLab {
+    owner = "pine64-org";
+    repo = "bes2600-firmware";
+    rev = "7a305de61771a84f1264866b204cf172df6d9195";
+    sha256 = "32O0f0d90n0PW1y8ITvKlLJcKTR3gvaq/c1cKoog98Q=";
+  };
+
+  buildPhase = ''
+    mkdir -p $out/lib/firmware
+    mv firmware/bes2600 $out/lib/firmware
+  '';
+
+  meta = with lib; {
+    description = "bes2600 firmware";
+    homepage = "https://gitlab.com/pine64-org/bes2600-firmware";
+    license = licenses.unfree;
+  };
+}

--- a/pkgs/linux-rockchip.nix
+++ b/pkgs/linux-rockchip.nix
@@ -37,6 +37,11 @@ let
     STMMAC_ETH = yes;
     VIDEO_HANTRO_ROCKCHIP = yes;
   };
+  pinetabKernelConfig = with lib.kernel; {
+    BES2600 = module;
+    BES2600_WLAN_STDIO = yes;
+    BES2600_DEBUGFS = yes;
+  };
 in with pkgs.linuxKernel; {
   linux_6_1 = pkgs.linuxPackages_6_1;
   linux_6_1_rockchip = packagesFor
@@ -46,18 +51,22 @@ in with pkgs.linuxKernel; {
   linux_6_6_rockchip = packagesFor
     (kernels.linux_6_6.override { structuredExtraConfig = kernelConfig; });
 
-  linux_6_6_pinetab = packagesFor (kernels.linux_6_6.override {
+  linux_6_8 = pkgs.linuxPackages_6_8;
+  linux_6_8_rockchip = packagesFor
+    (kernels.linux_6_8.override { structuredExtraConfig = kernelConfig; });
+
+  linux_6_8_pinetab = packagesFor (kernels.linux_6_8.override {
     argsOverride = {
       src = pkgs.fetchFromGitHub {
         owner = "dreemurrs-embedded";
         repo = "linux-pinetab2";
-        rev = "81e3aa387e0dcb349e0d3f3c05f2f62742f814d7";
-        sha256 = "kkO54FbexUuuvZNFDuTtFMokBgKrCZXTQDCzsSRZNDE=";
+        rev = "b8c008ccf5a0d49bb783d94ebb14e6b1808e055b";
+        sha256 = "1F4GB1U+RSRjTSE8yCFL+Psq21viu+nRxDizPX9vTRc=";
       };
-      version = "6.6.8-danctnix1";
-      modDirVersion = "6.6.8-danctnix1";
+      version = "6.8.0-danctnix1";
+      modDirVersion = "6.8.0-danctnix1";
     };
-    structuredExtraConfig = kernelConfig;
+    structuredExtraConfig = kernelConfig // pinetabKernelConfig;
   });
 }
 


### PR DESCRIPTION
I've tested this on PineTab2. It boots and when modprobing bes2600 it detects wifi networks. It seemed to crash when trying to connect, though. bes2600 is not loaded by default so this should be fine.

I haven't run 6.8 on any of my other boards yet, but it should be fine seeing as pinetab2 came up ok