### PR TITLE
Update linux 6.9 uboot 2024.04

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         package:
         - kernel_linux_6_6_rockchip.kernel
-        - kernel_linux_6_8_pinetab.kernel
+        - kernel_linux_6_9_pinetab.kernel
         - uBootRock64
         - uBootRockPro64
         - uBootPinebookPro

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -17,8 +17,8 @@ jobs:
       matrix:
         package:
         - kernel_linux_6_6_rockchip.kernel
-        - kernel_linux_6_8_rockchip.kernel
-        - kernel_linux_6_8_pinetab.kernel
+        - kernel_linux_6_9_rockchip.kernel
+        - kernel_linux_6_9_pinetab.kernel
         - uBootRock64
         - uBootRockPro64
         - uBootPinebookPro

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgsStable": {
       "locked": {
-        "lastModified": 1719145550,
-        "narHash": "sha256-K0i/coxxTEl30tgt4oALaylQfxqbotTSNb1/+g+mKMQ=",
+        "lastModified": 1719426051,
+        "narHash": "sha256-yJL9VYQhaRM7xs0M867ZFxwaONB9T2Q4LnGo1WovuR4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e4509b3a560c87a8d4cb6f9992b8915abf9e36d8",
+        "rev": "89c49874fb15f4124bf71ca5f42a04f2ee5825fd",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "nixpkgsUnstable": {
       "locked": {
-        "lastModified": 1719075281,
-        "narHash": "sha256-CyyxvOwFf12I91PBWz43iGT1kjsf5oi6ax7CrvaMyAo=",
+        "lastModified": 1719506693,
+        "narHash": "sha256-C8e9S7RzshSdHB7L+v9I51af1gDM5unhJ2xO1ywxNH8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a71e967ef3694799d0c418c98332f7ff4cc5f6af",
+        "rev": "b2852eb9365c6de48ffb0dc2c9562591f652242a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -73,7 +73,7 @@
         };
         "PineTab2" = {
           uBoot = (uBoot system).uBootPineTab2;
-          kernel = (kernel system).linux_6_8_pinetab;
+          kernel = (kernel system).linux_6_9_pinetab;
           extraModules = [ (bes2600 system) noZFS ];
         };
         "Rock64" = {
@@ -136,8 +136,8 @@
     } // inputs.utils.lib.eachDefaultSystem (system: {
       legacyPackages = {
         kernel_linux_6_6_rockchip = (kernel system).linux_6_6_rockchip;
-        kernel_linux_6_8_rockchip = (kernel system).linux_6_8_rockchip;
-        kernel_linux_6_8_pinetab = (kernel system).linux_6_8_pinetab;
+        kernel_linux_6_9_rockchip = (kernel system).linux_6_9_rockchip;
+        kernel_linux_6_9_pinetab = (kernel system).linux_6_9_pinetab;
       };
       packages = (images system) // {
         uBootQuartz64A = (uBoot system).uBootQuartz64A;

--- a/flake.nix
+++ b/flake.nix
@@ -44,9 +44,6 @@
         nixpkgs.config.allowUnfree = true;
         hardware.firmware = [ (bes2600Firmware system) ];
       };
-      pinetabPanel = {
-        boot.kernelModules = [ "panel_boe_th101mb31ig002_28a" ];
-      };
 
       boards = system: {
         "Quartz64A" = {
@@ -77,7 +74,7 @@
         "PineTab2" = {
           uBoot = (uBoot system).uBootPineTab2;
           kernel = (kernel system).linux_6_9_pinetab;
-          extraModules = [ (bes2600 system) noZFS pinetabPanel ];
+          extraModules = [ (bes2600 system) noZFS ];
         };
         "Rock64" = {
           uBoot = (uBoot system).uBootRock64;

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,9 @@
         nixpkgs.config.allowUnfree = true;
         hardware.firmware = [ (bes2600Firmware system) ];
       };
+      pinetabPanel = {
+        boot.kernelModules = [ "panel_boe_th101mb31ig002_28a" ];
+      };
 
       boards = system: {
         "Quartz64A" = {
@@ -74,7 +77,7 @@
         "PineTab2" = {
           uBoot = (uBoot system).uBootPineTab2;
           kernel = (kernel system).linux_6_9_pinetab;
-          extraModules = [ (bes2600 system) noZFS ];
+          extraModules = [ (bes2600 system) noZFS pinetabPanel ];
         };
         "Rock64" = {
           uBoot = (uBoot system).uBootRock64;

--- a/pkgs/backlight.patch
+++ b/pkgs/backlight.patch
@@ -1,0 +1,14 @@
+diff --git a/arch/arm64/configs/defconfig b/arch/arm64/configs/defconfig
+index 57a9abe78ee4..46db96bb88ff 100644
+--- a/arch/arm64/configs/defconfig
++++ b/arch/arm64/configs/defconfig
+@@ -923,7 +923,8 @@ CONFIG_DRM_POWERVR=m
+ CONFIG_FB=y
+ CONFIG_FB_EFI=y
+ CONFIG_FB_MODE_HELPERS=y
+-CONFIG_BACKLIGHT_PWM=m
++CONFIG_BACKLIGHT_CLASS_DEVICE=y
++CONFIG_BACKLIGHT_PWM=y
+ CONFIG_BACKLIGHT_LP855X=m
+ CONFIG_LOGO=y
+ # CONFIG_LOGO_LINUX_MONO is not set

--- a/pkgs/linux-rockchip.nix
+++ b/pkgs/linux-rockchip.nix
@@ -39,7 +39,7 @@ let
   };
   pinetabKernelConfig = with lib.kernel; {
     BES2600 = module;
-    BES2600_WLAN_STDIO = yes;
+    BES2600_5GHZ_SUPPORT = yes;
     BES2600_DEBUGFS = yes;
   };
 in with pkgs.linuxKernel; {
@@ -47,20 +47,20 @@ in with pkgs.linuxKernel; {
   linux_6_6_rockchip = packagesFor
     (kernels.linux_6_6.override { structuredExtraConfig = kernelConfig; });
 
-  linux_6_8 = pkgs.linuxPackages_6_8;
-  linux_6_8_rockchip = packagesFor
-    (kernels.linux_6_8.override { structuredExtraConfig = kernelConfig; });
+  linux_6_9 = pkgs.linuxPackages_6_9;
+  linux_6_9_rockchip = packagesFor
+    (kernels.linux_6_9.override { structuredExtraConfig = kernelConfig; });
 
-  linux_6_8_pinetab = packagesFor (kernels.linux_6_8.override {
+  linux_6_9_pinetab = packagesFor (kernels.linux_6_9.override {
     argsOverride = {
       src = pkgs.fetchFromGitHub {
         owner = "dreemurrs-embedded";
         repo = "linux-pinetab2";
-        rev = "b8c008ccf5a0d49bb783d94ebb14e6b1808e055b";
-        sha256 = "1F4GB1U+RSRjTSE8yCFL+Psq21viu+nRxDizPX9vTRc=";
+        rev = "40ef75b076fa34b2cde70a76770fe456fd425f7f";
+        sha256 = "wraIt2kBwgMNMzFX2DiLhPZGM2Z/2xLqUhS4vRL50vs=";
       };
-      version = "6.8.0-danctnix1";
-      modDirVersion = "6.8.0-danctnix1";
+      version = "6.9.6-danctnix1";
+      modDirVersion = "6.9.6-danctnix1";
     };
     structuredExtraConfig = kernelConfig // pinetabKernelConfig;
   });

--- a/pkgs/linux-rockchip.nix
+++ b/pkgs/linux-rockchip.nix
@@ -6,6 +6,7 @@ let
     CHARGER_RK817 = yes;
     COMMON_CLK_RK808 = yes;
     COMMON_CLK_ROCKCHIP = yes;
+    DRM_ROCKCHIP = yes;
     GPIO_ROCKCHIP = yes;
     MFD_RK808 = yes;
     MMC_DW = yes;
@@ -41,6 +42,8 @@ let
     BES2600 = module;
     BES2600_5GHZ_SUPPORT = yes;
     BES2600_DEBUGFS = yes;
+
+    DRM_PANEL_BOE_TH101MB31UIG002_28A = yes;
   };
 in with pkgs.linuxKernel; {
   linux_6_6 = pkgs.linuxPackages_6_6;
@@ -62,6 +65,10 @@ in with pkgs.linuxKernel; {
       version = "6.9.6-danctnix1";
       modDirVersion = "6.9.6-danctnix1";
     };
+    kernelPatches = [{
+      name = "Enable backlight in defconfig";
+      patch = ./backlight.patch;
+    }];
     structuredExtraConfig = kernelConfig // pinetabKernelConfig;
   });
 }

--- a/pkgs/uboot-rockchip.nix
+++ b/pkgs/uboot-rockchip.nix
@@ -7,50 +7,17 @@ let
       src = fetchFromGitHub {
         owner = "u-boot";
         repo = "u-boot";
-        rev = "v2023.10";
-        sha256 = "f0xDGxTatRtCxwuDnmsqFLtYLIyjA5xzyQcwfOy3zEM=";
+        rev = "v2024.04";
+        sha256 = "IlaDdjKq/Pq2orzcU959h93WXRZfvKBGDO/MFw9mZMg=";
       };
-      version = "v2023.10-69-g0bc339ffa6"; # git describe --long
+      version = "v2024.04-0-g25049ad5608"; # git describe --long
     in buildUBoot {
       src = src;
       version = version;
       defconfig = defconfig;
       filesToInstall = [ "u-boot-rockchip.bin" ];
 
-      patches = [
-        (fetchpatch {
-          name = "quartz64.patch";
-          url =
-            "https://github.com/Kwiboo/u-boot-rockchip/compare/4459ed60cb1e0562bc5b40405e2b4b9bbf766d57...0bc339ffa6f804d51c5c5292d8ff69c4d79614d3.diff";
-          sha256 = "ui77Nm3IS6PUzaMagqyyZDitklot8MmeYg27mVPV7Pc=";
-        })
-        ./ramdisk_addr_r.patch
-      ];
-
-      buildInputs = with buildPackages; [
-        ncurses # tools/kwboot
-        libuuid # tools/mkeficapsule
-        gnutls # tools/mkeficapsule
-        openssl # tools/imagetool
-      ];
-
-      nativeBuildInputs = with buildPackages; [
-        ncurses # tools/kwboot
-        bc
-        bison
-        dtc
-        flex
-        openssl
-        (python3.withPackages (p: [
-          p.libfdt
-          p.setuptools # for pkg_resources
-          p.pyelftools
-        ]))
-        swig
-        which # for scripts/dtc-version.sh
-      ];
-
-      makeFlags = [ "CROSS_COMPILE=${stdenv.cc.targetPrefix}" ];
+      extraPatches = [ ./ramdisk_addr_r.patch ];
 
       BL31 = BL31;
       ROCKCHIP_TPL = ROCKCHIP_TPL;

--- a/pkgs/uboot-rockchip.nix
+++ b/pkgs/uboot-rockchip.nix
@@ -1,9 +1,9 @@
 { pkgs, stdenv, lib, fetchpatch, fetchFromGitHub, buildUBoot, buildPackages }:
 
 let
-  buildPatchedUBoot = { defconfig, BL31, ROCKCHIP_TPL ? "" }:
+  buildPatchedUBoot = { defconfig, BL31, ROCKCHIP_TPL ? "", extraPatches ? [] }:
     let
-      inherit defconfig BL31 ROCKCHIP_TPL;
+      inherit defconfig BL31 ROCKCHIP_TPL extraPatches;
       src = fetchFromGitHub {
         owner = "u-boot";
         repo = "u-boot";
@@ -17,7 +17,7 @@ let
       defconfig = defconfig;
       filesToInstall = [ "u-boot-rockchip.bin" ];
 
-      extraPatches = [ ./ramdisk_addr_r.patch ];
+      extraPatches = [ ./ramdisk_addr_r.patch ] ++ extraPatches;
 
       BL31 = BL31;
       ROCKCHIP_TPL = ROCKCHIP_TPL;
@@ -47,6 +47,14 @@ let
       };
     in buildPatchedUBoot {
       inherit defconfig;
+      extraPatches = [
+        (fetchpatch {
+          name = "quartz64.patch";
+          url =
+            "https://github.com/Kwiboo/u-boot-rockchip/compare/25049ad560826f7dc1c4740883b0016014a59789...830cfcfdf54a1f08a3ca7fc17e69b4bc18cece50.diff";
+          sha256 = "5mLjKiRpfnLCNVnyNuxBcDmmXg8xwcki3mmLisS4YbU=";
+        })
+      ];
       BL31 = (rkbin + "/bin/rk35/rk3568_bl31_v1.43.elf");
       ROCKCHIP_TPL = (rkbin + "/bin/rk35/rk3566_ddr_1056MHz_v1.18.bin");
     };

--- a/pkgs/uboot-rockchip.nix
+++ b/pkgs/uboot-rockchip.nix
@@ -1,7 +1,8 @@
 { pkgs, stdenv, lib, fetchpatch, fetchFromGitHub, buildUBoot, buildPackages }:
 
 let
-  buildPatchedUBoot = { defconfig, BL31, ROCKCHIP_TPL ? "", extraPatches ? [] }:
+  buildPatchedUBoot =
+    { defconfig, BL31, ROCKCHIP_TPL ? "", extraPatches ? [ ] }:
     let
       inherit defconfig BL31 ROCKCHIP_TPL extraPatches;
       src = fetchFromGitHub {


### PR DESCRIPTION
The display for pinetab2 got upstreamed in 6.9 but I couldn't figure out how to enable it without patching defconfig

I also simplified the uboot build config since we didn't have much different from upstream

WiFi works on PineTab2 btw