### PR TITLE
Add Radxa Rock 4 (old name Rock Pi 4)

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -38,6 +38,7 @@ jobs:
         - uBootSoQuartzCM4IO
         - uBootSoQuartzBlade
         - uBootOrangePiCM4
+        - uBootRadxaRock4
     runs-on: ubuntu-latest
     steps:
     - name: Free disk space

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -30,6 +30,7 @@ jobs:
         - uBootSoQuartzCM4IO
         - uBootSoQuartzBlade
         - uBootOrangePiCM4
+        - uBootRadxaRock4
     runs-on: ubuntu-latest
     steps:
     - name: Free disk space
@@ -129,6 +130,7 @@ jobs:
         - PinebookPro
         - PineTab2
         - OrangePiCM4
+        - RadxaRock4
     runs-on: ubuntu-latest
     steps:
     - name: Free disk space

--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,11 @@
           kernel = (kernel system).linux_6_6_rockchip;
           extraModules = [ ];
         };
+        "RadxaRock4" = {
+          uBoot = (uBoot system).uBootRadxaRock4;
+          kernel = (kernel system).linux_6_6_rockchip;
+          extraModules = [ ];
+        };
       };
 
       osConfigs = system:
@@ -153,6 +158,8 @@
         uBootSoQuartzBlade = (uBoot system).uBootSoQuartzBlade;
 
         uBootOrangePiCM4 = (uBoot system).uBootOrangePiCM4;
+
+        uBootRadxaRock4 = (uBoot system).uBootRadxaRock4;
 
         bes2600 = (bes2600Firmware system);
       };

--- a/pkgs/uboot-rockchip.nix
+++ b/pkgs/uboot-rockchip.nix
@@ -71,4 +71,5 @@ in {
   uBootROCPCRK3399 = buildRK3399UBoot "roc-pc-rk3399_defconfig";
   uBootRock64 = buildRK3328UBoot "rock64-rk3328_defconfig";
   uBootOrangePiCM4 = buildRK3566UBoot "orangepi-3b-rk3566_defconfig";
+  uBootRadxaRock4 = buildRK3399UBoot "rock-pi-4-rk3399_defconfig";
 }


### PR DESCRIPTION
The Raxa family of 3399-based boards are now called "Rock 4", but the two boards that I have are labelled "Rock Pi 4" xxx.

At present, there is no distinguishing between the various models in any of the Nix files. I don't know if there needs to be. I have tested on a Rock Pi 4 SE, and when U-Boot starts it outputs: `Model: Radxa ROCK Pi 4A`.

At this point, I have only verified that the build image boots successfully. I will do additional testing and also test on a Rock Pi 4B+.

**Update:** I also booted the Rock Pi 4B+ and verified that Ethernet can ping the router on both boards.

This PR addresses one of the two boards requested in Issue #25 