### PR TITLE
Add RadxaCM3IO

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -38,6 +38,7 @@ jobs:
         - uBootSoQuartzCM4IO
         - uBootSoQuartzBlade
         - uBootOrangePiCM4
+        - uBootRadxaCM3IO
     runs-on: ubuntu-latest
     steps:
     - name: Free disk space

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -30,6 +30,7 @@ jobs:
         - uBootSoQuartzCM4IO
         - uBootSoQuartzBlade
         - uBootOrangePiCM4
+        - uBootRadxaCM3IO
     runs-on: ubuntu-latest
     steps:
     - name: Free disk space
@@ -129,6 +130,7 @@ jobs:
         - PinebookPro
         - PineTab2
         - OrangePiCM4
+        - RadxaCM3IO
     runs-on: ubuntu-latest
     steps:
     - name: Free disk space

--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,11 @@
           kernel = (kernel system).linux_6_6_rockchip;
           extraModules = [ ];
         };
+        "RadxaCM3IO" = {
+          uBoot = (uBoot system).uBootRadxaCM3IO;
+          kernel = (kernel system).linux_6_6_rockchip;
+          extraModules = [ ];
+        };
       };
 
       osConfigs = system:
@@ -153,6 +158,8 @@
         uBootSoQuartzBlade = (uBoot system).uBootSoQuartzBlade;
 
         uBootOrangePiCM4 = (uBoot system).uBootOrangePiCM4;
+
+        uBootRadxaCM3IO = (uBoot system).uBootRadxaCM3IO;
 
         bes2600 = (bes2600Firmware system);
       };

--- a/pkgs/uboot-rockchip.nix
+++ b/pkgs/uboot-rockchip.nix
@@ -71,4 +71,5 @@ in {
   uBootROCPCRK3399 = buildRK3399UBoot "roc-pc-rk3399_defconfig";
   uBootRock64 = buildRK3328UBoot "rock64-rk3328_defconfig";
   uBootOrangePiCM4 = buildRK3566UBoot "orangepi-3b-rk3566_defconfig";
+  uBootRadxaCM3IO = buildRK3566UBoot "radxa-cm3-io-rk3566_defconfig";
 }


### PR DESCRIPTION
This PR implements Radxa CM3 (on Radxa's CM3 I/O board, according to the U-Boot config) which is related to the request in Issue #25 (which actually requested CM3 on Raspberry Pi's CM4 I/O board)
