### PR TITLE
flake.nix: Update Radxa boards to use linux_6_12_rockchip

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -103,18 +103,18 @@
         };
         "RadxaCM3IO" = {
           uBoot = (uBoot system).uBootRadxaCM3IO;
-          kernel = (kernel system).linux_6_6_rockchip;
-          extraModules = [ ];
+          kernel = (kernel system).linux_6_12_rockchip;
+          extraModules = [ noZFS ];
         };
         "RadxaRock4" = {
           uBoot = (uBoot system).uBootRadxaRock4;
-          kernel = (kernel system).linux_6_6_rockchip;
-          extraModules = [ ];
+          kernel = (kernel system).linux_6_12_rockchip;
+          extraModules = [ noZFS ];
         };
         "RadxaRock4SE" = {
           uBoot = (uBoot system).uBootRadxaRock4SE;
-          kernel = (kernel system).linux_6_6_rockchip;
-          extraModules = [ ];
+          kernel = (kernel system).linux_6_12_rockchip;
+          extraModules = [ noZFS ];
         };
       };
 


### PR DESCRIPTION
This is tested on Rock 4B and Rock 4SE.  (I don't have a CM3 w/CM3 I/O board to test on.)

I added `noZFS` to `extraModules` for each of the Radxa boards. This is needed because the ZFS build is marked as broken.

~~This is a child of PR #31, so is marked as DRAFT until that one is merged.~~