### PR TITLE
GitHub Actions: Upgrade to run on ubuntu-24.04

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: |
         DEBIAN_FRONTEND=noninteractive
-        sudo apt-get update -q -y && sudo apt-get install -q -y qemu-system-aarch64 qemu-efi binfmt-support qemu-user-static
+        sudo apt-get update -q -y && sudo apt-get install -q -y qemu-system-aarch64 qemu-efi-aarch64 binfmt-support qemu-user-static
     - uses: cachix/install-nix-action@v20
       with:
         nix_path: nixpkgs=channel:nixos-unstable
@@ -78,7 +78,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: |
         DEBIAN_FRONTEND=noninteractive
-        sudo apt-get update -q -y && sudo apt-get install -q -y qemu-system-aarch64 qemu-efi binfmt-support qemu-user-static
+        sudo apt-get update -q -y && sudo apt-get install -q -y qemu-system-aarch64 qemu-efi-aarch64 binfmt-support qemu-user-static
     - uses: cachix/install-nix-action@v20
       with:
         nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   fmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v20
@@ -41,7 +41,7 @@ jobs:
         - uBootRadxaCM3IO
         - uBootRadxaRock4
         - uBootRadxaRock4SE
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Free disk space
       run: |
@@ -67,7 +67,7 @@ jobs:
 
   build_example:
     needs: fmt
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Free disk space
       run: |

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -44,7 +44,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: |
         DEBIAN_FRONTEND=noninteractive
-        sudo apt-get update -q -y && sudo apt-get install -q -y qemu-system-aarch64 qemu-efi binfmt-support qemu-user-static
+        sudo apt-get update -q -y && sudo apt-get install -q -y qemu-system-aarch64 qemu-efi-aarch64 binfmt-support qemu-user-static
     - uses: cachix/install-nix-action@v20
       with:
         nix_path: nixpkgs=channel:nixos-unstable
@@ -65,7 +65,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: |
         DEBIAN_FRONTEND=noninteractive
-        sudo apt-get update -q -y && sudo apt-get install -q -y qemu-system-aarch64 qemu-efi binfmt-support qemu-user-static
+        sudo apt-get update -q -y && sudo apt-get install -q -y qemu-system-aarch64 qemu-efi-aarch64 binfmt-support qemu-user-static
     - uses: cachix/install-nix-action@v20
       with:
         nix_path: nixpkgs=channel:nixos-unstable
@@ -146,7 +146,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: |
         DEBIAN_FRONTEND=noninteractive
-        sudo apt-get update -q -y && sudo apt-get install -q -y qemu-system-aarch64 qemu-efi binfmt-support qemu-user-static
+        sudo apt-get update -q -y && sudo apt-get install -q -y qemu-system-aarch64 qemu-efi-aarch64 binfmt-support qemu-user-static
     - uses: cachix/install-nix-action@v20
       with:
         nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -33,7 +33,7 @@ jobs:
         - uBootRadxaCM3IO
         - uBootRadxaRock4
         - uBootRadxaRock4SE
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Free disk space
       run: |
@@ -59,7 +59,7 @@ jobs:
         nix build -L -j4 .#${{ matrix.package }}
 
   build_example:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build_packages
     steps:
     - uses: actions/checkout@v3
@@ -82,7 +82,7 @@ jobs:
         nix build -L -j4 --accept-flake-config --override-input rockchip ..
 
   create_release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [build_packages, build_example]
     steps:
     - uses: actions/checkout@v3
@@ -135,7 +135,7 @@ jobs:
         - RadxaCM3IO
         - RadxaRock4
         - RadxaRock4SE
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Free disk space
       run: |

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   flake_update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v20


### PR DESCRIPTION
Warnings are being generated saying ubuntu-latest is upgrading to Ubuntu 24.04 soon. Let's test the upgrade and consider using an explicit version so changes aren't made external to our build.

This breaks the build, so is a DRAFT PR until either:

1. Additional changes are made to this PR so the build works on Ubuntu 24.04
2. We decide to switch to explicitly using `ubuntu-22.04` 
