### PR TITLE
GitHub Actions: use ubuntu-22.04 instead of -latest

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   fmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v20
@@ -41,7 +41,7 @@ jobs:
         - uBootRadxaCM3IO
         - uBootRadxaRock4
         - uBootRadxaRock4SE
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Free disk space
       run: |
@@ -67,7 +67,7 @@ jobs:
 
   build_example:
     needs: fmt
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Free disk space
       run: |

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -33,7 +33,7 @@ jobs:
         - uBootRadxaCM3IO
         - uBootRadxaRock4
         - uBootRadxaRock4SE
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Free disk space
       run: |
@@ -59,7 +59,7 @@ jobs:
         nix build -L -j4 .#${{ matrix.package }}
 
   build_example:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build_packages
     steps:
     - uses: actions/checkout@v3
@@ -82,7 +82,7 @@ jobs:
         nix build -L -j4 --accept-flake-config --override-input rockchip ..
 
   create_release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build_packages, build_example]
     steps:
     - uses: actions/checkout@v3
@@ -135,7 +135,7 @@ jobs:
         - RadxaCM3IO
         - RadxaRock4
         - RadxaRock4SE
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Free disk space
       run: |

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   flake_update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v20


### PR DESCRIPTION
As of today, this should not change the behavior of the build because ubuntu-latest and ubuntu-22.04 are identical. But when -latest is upgraded, it will switch to ubuntu-24.04.

This PR is a fallback, for use if we don't get a working PR for ubuntu-24.04 before GitHub "upgrades" us.