### PR TITLE
Fix nvme on rk3566

### DIFF
--- a/pkgs/fix-nvme.patch
+++ b/pkgs/fix-nvme.patch
@@ -1,0 +1,37 @@
+From 3126ea9be66b53e607f87f067641ba724be24181 Mon Sep 17 00:00:00 2001
+From: Chukun Pan <amadeus@jmu.edu.cn>
+Date: Mon, 6 Jan 2025 18:00:01 +0800
+Subject: phy: rockchip: naneng-combphy: compatible reset with old DT
+
+The device tree of RK3568 did not specify reset-names before.
+So add fallback to old behaviour to be compatible with old DT.
+
+Fixes: fbcbffbac994 ("phy: rockchip: naneng-combphy: fix phy reset")
+Cc: Jianfeng Liu <liujianfeng1994@gmail.com>
+Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
+Reviewed-by: Jonas Karlman <jonas@kwiboo.se>
+Link: https://lore.kernel.org/r/20250106100001.1344418-2-amadeus@jmu.edu.cn
+Signed-off-by: Vinod Koul <vkoul@kernel.org>
+---
+ drivers/phy/rockchip/phy-rockchip-naneng-combphy.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/phy/rockchip/phy-rockchip-naneng-combphy.c b/drivers/phy/rockchip/phy-rockchip-naneng-combphy.c
+index a1532ef8bbe9d6..8c3ce57f89151f 100644
+--- a/drivers/phy/rockchip/phy-rockchip-naneng-combphy.c
++++ b/drivers/phy/rockchip/phy-rockchip-naneng-combphy.c
+@@ -324,7 +324,10 @@ static int rockchip_combphy_parse_dt(struct device *dev, struct rockchip_combphy
+ 
+ 	priv->ext_refclk = device_property_present(dev, "rockchip,ext-refclk");
+ 
+-	priv->phy_rst = devm_reset_control_get(dev, "phy");
++	priv->phy_rst = devm_reset_control_get_exclusive(dev, "phy");
++	/* fallback to old behaviour */
++	if (PTR_ERR(priv->phy_rst) == -ENOENT)
++		priv->phy_rst = devm_reset_control_array_get_exclusive(dev);
+ 	if (IS_ERR(priv->phy_rst))
+ 		return dev_err_probe(dev, PTR_ERR(priv->phy_rst), "failed to get phy reset\n");
+ 
+-- 
+cgit 1.2.3-korg
+

--- a/pkgs/linux-rockchip.nix
+++ b/pkgs/linux-rockchip.nix
@@ -47,11 +47,23 @@ let
 in with pkgs.linuxKernel; {
   linux_6_6 = pkgs.linuxPackages_6_6;
   linux_6_6_rockchip = packagesFor
-    (kernels.linux_6_6.override { structuredExtraConfig = kernelConfig; });
+    (kernels.linux_6_6.override {
+      structuredExtraConfig = kernelConfig;
+      kernelPatches = [{
+        name = "Fix nvme on rk3566";
+        patch = ./fix-nvme.patch;
+      }];
+    });
 
   linux_6_12 = pkgs.linuxPackages_6_12;
   linux_6_12_rockchip = packagesFor
-    (kernels.linux_6_12.override { structuredExtraConfig = kernelConfig; });
+    (kernels.linux_6_12.override {
+      structuredExtraConfig = kernelConfig;
+      kernelPatches = [{
+        name = "Fix nvme on rk3566";
+        patch = ./fix-nvme.patch;
+      }];
+    });
 
   linux_6_12_pinetab = packagesFor (kernels.linux_6_12.override {
     argsOverride = {

--- a/pkgs/linux-rockchip.nix
+++ b/pkgs/linux-rockchip.nix
@@ -46,24 +46,22 @@ let
   };
 in with pkgs.linuxKernel; {
   linux_6_6 = pkgs.linuxPackages_6_6;
-  linux_6_6_rockchip = packagesFor
-    (kernels.linux_6_6.override {
-      structuredExtraConfig = kernelConfig;
-      kernelPatches = [{
-        name = "Fix nvme on rk3566";
-        patch = ./fix-nvme.patch;
-      }];
-    });
+  linux_6_6_rockchip = packagesFor (kernels.linux_6_6.override {
+    structuredExtraConfig = kernelConfig;
+    kernelPatches = [{
+      name = "Fix nvme on rk3566";
+      patch = ./fix-nvme.patch;
+    }];
+  });
 
   linux_6_12 = pkgs.linuxPackages_6_12;
-  linux_6_12_rockchip = packagesFor
-    (kernels.linux_6_12.override {
-      structuredExtraConfig = kernelConfig;
-      kernelPatches = [{
-        name = "Fix nvme on rk3566";
-        patch = ./fix-nvme.patch;
-      }];
-    });
+  linux_6_12_rockchip = packagesFor (kernels.linux_6_12.override {
+    structuredExtraConfig = kernelConfig;
+    kernelPatches = [{
+      name = "Fix nvme on rk3566";
+      patch = ./fix-nvme.patch;
+    }];
+  });
 
   linux_6_12_pinetab = packagesFor (kernels.linux_6_12.override {
     argsOverride = {


### PR DESCRIPTION
The break got backported to 6.6 and 6.12. This fix will likely get backported as well but for now we carry the patch

fixes https://github.com/nabam/nixos-rockchip/issues/44