### PR TITLE
GHA checks.yaml: fail-fast false on build_packages

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -23,6 +23,7 @@ jobs:
   build_packages:
     needs: fmt
     strategy:
+      fail-fast: false
       matrix:
         package:
         - kernel_linux_6_6_rockchip.kernel


### PR DESCRIPTION
If there is a failure, this will allow us to see which packages are building and which are not, rather than just failing when the first package fails to build.