### PR TITLE
uboot-PineTab2: update to 2026.01

### DIFF
--- a/pkgs/uboot-rockchip.nix
+++ b/pkgs/uboot-rockchip.nix
@@ -143,15 +143,6 @@ in
     spi = false;
   };
   uBootPineTab2 = buildUBoot rec {
-    # Pick 2025.07 for now since that's what the vop2 patchset
-    # is against
-    version = "v2025.07";
-    src = fetchFromGitHub {
-      owner = "u-boot";
-      repo = "u-boot";
-      tag = version;
-      sha256 = "sha256-X+JhVkDudkvQo08hGwAChOeMZZR+iunT9aU6tSAuMmg=";
-    };
     defconfig = "pinetab2-rk3566_defconfig";
     filesToInstall = [
       "u-boot-rockchip.bin"
@@ -166,8 +157,8 @@ in
       # https://lists.denx.de/pipermail/u-boot/2025-January/thread.html#577641
       (fetchurl {
         name = "rockchip-video-output-processor-2.patch";
-        url = "https://raw.githubusercontent.com/dreemurrs-embedded/danctnix-packages/d2ba844cb9fdcda092f54f87827f8705727ce261/pine64/uboot-pinetab2/vop2.patch";
-        hash = "sha256-m04GQUvovmo7EuMvHjvxALc+dcBnn9l4TClOspd5i0k=";
+        url = "https://raw.githubusercontent.com/dreemurrs-embedded/danctnix-packages/e23913eb6cf1bcaa9a5de41d15a6275ab181a944/pine64/uboot-pinetab2/vop2.patch";
+        hash = "sha256-m3NJYuAc0JI6JTxCm+69SGpnEJRu2JNnFulLUj2dugg=";
       })
     ];
     env = {


### PR DESCRIPTION
Draft because first needs:

* [x] tested: boots, video and usb keyboard work
* [x] https://github.com/NixOS/nixpkgs/pull/505203 to be merged
* [x] this change to [make it to nixpkgs-unstable](https://nixpk.gs/pr-tracker.html?pr=505203)
* [x] nixpkgs-unstable to be updated in this repo

(I guess we could skip '2' and '3' and set uboot `src =` to a custom value again, but I don't see a reason to be in any hurry, fine to wait for upstream imho)