### PR TITLE
update nixpkgs-unstable, includes update to 2026.04

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgsUnstable": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {

--- a/pkgs/uboot-rockchip.nix
+++ b/pkgs/uboot-rockchip.nix
@@ -143,15 +143,6 @@ in
     spi = false;
   };
   uBootPineTab2 = buildUBoot rec {
-    # Pick 2025.07 for now since that's what the vop2 patchset
-    # is against
-    version = "v2025.07";
-    src = fetchFromGitHub {
-      owner = "u-boot";
-      repo = "u-boot";
-      tag = version;
-      sha256 = "sha256-X+JhVkDudkvQo08hGwAChOeMZZR+iunT9aU6tSAuMmg=";
-    };
     defconfig = "pinetab2-rk3566_defconfig";
     filesToInstall = [
       "u-boot-rockchip.bin"
@@ -166,8 +157,8 @@ in
       # https://lists.denx.de/pipermail/u-boot/2025-January/thread.html#577641
       (fetchurl {
         name = "rockchip-video-output-processor-2.patch";
-        url = "https://raw.githubusercontent.com/dreemurrs-embedded/danctnix-packages/d2ba844cb9fdcda092f54f87827f8705727ce261/pine64/uboot-pinetab2/vop2.patch";
-        hash = "sha256-m04GQUvovmo7EuMvHjvxALc+dcBnn9l4TClOspd5i0k=";
+        url = "https://raw.githubusercontent.com/dreemurrs-embedded/danctnix-packages/6d8f2ce32260e8f94fded5c3ec4b2f983a64db49/pine64/uboot-pinetab2/vop2.patch";
+        hash = "sha256-LTuhALreDCc6hSyc7N7Q2i0x/+bvkDdzQ62r45iZjc8=";
       })
     ];
     env = {


### PR DESCRIPTION
Tested on PineTab2: builds, video out and USB keyboard work uboot, successfully boots.

<img width="1079" height="960" alt="_20260424_165334" src="https://github.com/user-attachments/assets/3c7425f8-44f6-48dd-a256-6c0000c09368" />
