### PR TITLE
feat: add Orange Pi 3B

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -43,6 +43,7 @@ jobs:
         - uBootSoQuartzCM4IO
         - uBootSoQuartzBlade
         - uBootOrangePiCM4
+        - uBootOrangePi3B
         - uBootRadxaCM3IO
         - uBootRadxaRock4
         - uBootRadxaRock4CPlus

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -37,6 +37,7 @@ jobs:
         - uBootSoQuartzCM4IO
         - uBootSoQuartzBlade
         - uBootOrangePiCM4
+        - uBootOrangePi3B
         - uBootRadxaCM3IO
         - uBootRadxaRock4
         - uBootRadxaRock4CPlus

--- a/flake.nix
+++ b/flake.nix
@@ -138,6 +138,14 @@
             kernel = kernel.linux_6_17_rockchip_stable;
             extraModules = [ noZFS ];
           };
+          "OrangePi3B" = {
+            uBoot = uBoot.uBootOrangePi3B;
+            kernel = kernel.linux_latest_rockchip_unstable;
+            extraModules = [
+              noZFS
+              { boot.initrd.allowMissingModules = true; }
+            ];
+          };
           "OrangePi5B" = {
             uBoot = uBoot.uBootOrangePi5B;
             kernel = kernel.linux_6_17_orangepi5b_stable;
@@ -235,6 +243,7 @@
           uBootSoQuartzBlade = uBoot.uBootSoQuartzBlade;
 
           uBootOrangePiCM4 = uBoot.uBootOrangePiCM4;
+          uBootOrangePi3B = uBoot.uBootOrangePi3B;
           uBootOrangePi5B = uBoot.uBootOrangePi5B;
 
           uBootRadxaCM3IO = uBoot.uBootRadxaCM3IO;

--- a/pkgs/uboot-rockchip.nix
+++ b/pkgs/uboot-rockchip.nix
@@ -174,6 +174,7 @@ in
   uBootROCPCRK3399 = buildRK3399UBoot "roc-pc-rk3399_defconfig";
   uBootRock64 = buildRK3328UBoot "rock64-rk3328_defconfig";
   uBootOrangePiCM4 = buildRK3566UBoot { defconfig = "orangepi-3b-rk3566_defconfig"; };
+  uBootOrangePi3B = buildRK3566UBoot { defconfig = "orangepi-3b-rk3566_defconfig"; };
   uBootOrangePi5B = buildRK3588UBoot "orangepi-5b-rk3588s_defconfig";
   uBootRadxaCM3IO = buildRK3566UBoot {
     defconfig = "radxa-cm3-io-rk3566_defconfig";


### PR DESCRIPTION
Tested `kernel_linux_latest_rockchip_unstable` on my Orange Pi 3B, booting from NVMe works fine

http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/service-and-support/Orange-Pi-3B.html

<img width="748" height="439" alt="image" src="https://github.com/user-attachments/assets/7ae95702-b15c-403b-a537-591ca625b78c" />
