### PR TITLE
Move the Opi5B kernel to 6.18

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -140,7 +140,7 @@
           };
           "OrangePi5B" = {
             uBoot = uBoot.uBootOrangePi5B;
-            kernel = kernel.linux_6_17_orangepi5b_stable;
+            kernel = kernel.linux_6_18_orangepi5b_stable;
             extraModules = [
               (brcm43752 system)
               noZFS
@@ -218,8 +218,8 @@
           kernel_linux_6_18_pinetab_stable = kernel.linux_6_18_pinetab_stable;
           kernel_linux_6_19_pinetab_unstable = kernel.linux_6_19_pinetab_unstable;
 
-          kernel_linux_6_17_orangepi5b_stable = kernel.linux_6_17_orangepi5b_stable;
-          kernel_linux_6_17_orangepi5b_unstable = kernel.linux_6_17_orangepi5b_unstable;
+          kernel_linux_6_18_orangepi5b_stable = kernel.linux_6_18_orangepi5b_stable;
+          kernel_linux_6_18_orangepi5b_unstable = kernel.linux_6_18_orangepi5b_unstable;
         };
         packages = (images system) // {
           uBootQuartz64A = uBoot.uBootQuartz64A;

--- a/pkgs/linux-rockchip.nix
+++ b/pkgs/linux-rockchip.nix
@@ -110,8 +110,8 @@ in
       }
     );
 
-  linux_6_17_orangepi5b_stable = pkgs-stable.linuxKernel.packagesFor (
-    pkgs-stable.linuxKernel.kernels.linux_6_17.override {
+  linux_6_18_orangepi5b_stable = pkgs-stable.linuxKernel.packagesFor (
+    pkgs-stable.linuxKernel.kernels.linux_6_18.override {
       structuredExtraConfig = kernelConfig;
       kernelPatches = [
         {
@@ -122,8 +122,8 @@ in
     }
   );
 
-  linux_6_17_orangepi5b_unstable = pkgs.linuxKernel.packagesFor (
-    pkgs.linuxKernel.kernels.linux_6_17.override {
+  linux_6_18_orangepi5b_unstable = pkgs.linuxKernel.packagesFor (
+    pkgs.linuxKernel.kernels.linux_6_18.override {
       structuredExtraConfig = kernelConfig;
       kernelPatches = [
         {


### PR DESCRIPTION
I tested Linux 6.18.2 on my OrangePi5B. Everything is working as expected. Using 6.18 rather than latest as 6.18 has LTS.