### PR TITLE
update nixpkgsStable to 25.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgsStable": {
       "locked": {
-        "lastModified": 1767313136,
-        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "lastModified": 1779102034,
+        "narHash": "sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "rev": "687f05a9184cad4eaf905c48b63649e3a86f5433",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Build NixOS images for rockchip based computers";
 
   inputs = {
-    nixpkgsStable.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgsStable.url = "github:NixOS/nixpkgs/nixos-25.11";
     nixpkgsUnstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     utils.url = "github:numtide/flake-utils";
   };

--- a/pkgs/uboot-rockchip.nix
+++ b/pkgs/uboot-rockchip.nix
@@ -42,8 +42,10 @@ let
         "CONFIG_BOOTM_EFI=y"
       ];
 
-      BL31 = BL31;
-      ROCKCHIP_TPL = ROCKCHIP_TPL;
+      env = {
+        BL31 = BL31;
+        ROCKCHIP_TPL = ROCKCHIP_TPL;
+      };
 
       extraMeta = {
         platforms = [ "aarch64-linux" ];
@@ -99,8 +101,10 @@ let
           sha256 = "5mLjKiRpfnLCNVnyNuxBcDmmXg8xwcki3mmLisS4YbU=";
         })
       ];
-      BL31 = (rkbin + "/bin/rk35/rk3568_bl31_v1.43.elf");
-      ROCKCHIP_TPL = (rkbin + "/bin/rk35/rk3566_ddr_1056MHz_v1.18.bin");
+      env = {
+        BL31 = (rkbin + "/bin/rk35/rk3568_bl31_v1.43.elf");
+        ROCKCHIP_TPL = (rkbin + "/bin/rk35/rk3566_ddr_1056MHz_v1.18.bin");
+      };
     };
   buildRK3588UBoot =
     defconfig:
@@ -115,12 +119,14 @@ let
     pkgs-stable.buildUBoot {
       inherit defconfig src;
       version = "v2025.01-1-ga79ebd4e16";
-      BL31 = "${pkgs-stable.armTrustedFirmwareRK3588}/bl31.elf";
-      ROCKCHIP_TPL = pkgs-stable.rkbin.TPL_RK3588;
       filesToInstall = [ "u-boot-rockchip.bin" ];
       extraPatches = [
         ./patches/u-boot/2025.01/0001-Add-config-for-the-orangepi-5b-board.patch
       ];
+      env = {
+        BL31 = "${pkgs-stable.armTrustedFirmwareRK3588}/bl31.elf";
+        ROCKCHIP_TPL = pkgs-stable.rkbin.TPL_RK3588;
+      };
       extraMeta = {
         platforms = [ "aarch64-linux" ];
         license = pkgs-stable.lib.licenses.unfreeRedistributableFirmware;


### PR DESCRIPTION
on top of #89 to avoid CI failures

built the PineTab2 image and that still boots fine (full uboot+kernel to console)