### PR TITLE
pinetab2: build from various sources

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -23,6 +23,7 @@ jobs:
         - kernel_linux_latest_rockchip_stable.kernel
         - kernel_linux_latest_rockchip_unstable.kernel
         - kernel_linux_6_18_pinetab_stable.kernel
+        - kernel_linux_7_0_pinetab_stable.kernel
         - kernel_linux_7_0_pinetab_unstable.kernel
         # - kernel_linux_6_17_orangepi5b_stable.kernel
         # - kernel_linux_6_17_orangepi5b_unstable.kernel

--- a/flake.nix
+++ b/flake.nix
@@ -51,12 +51,6 @@
         ];
       };
 
-      bes2600 =
-        system: with (scope system); {
-          nixpkgs.config.allowUnfree = true;
-          hardware.firmware = [ bes2600Firmware ];
-        };
-
       brcm43752 =
         system: with (scope system); {
           nixpkgs.config.allowUnfree = true;
@@ -104,10 +98,11 @@
           };
           "PineTab2" = {
             uBoot = uBoot.uBootPineTab2;
-            kernel = kernel.linux_6_18_pinetab_stable;
+            kernel = kernel.linux_7_0_pinetab_stable;
             extraModules = [
-              (bes2600 system)
               noZFS
+              self.nixosModules.dtOverlayPineTab2
+              self.nixosModules.bes2600
             ];
           };
           "Rock64" = {
@@ -207,6 +202,8 @@
         dtOverlayQuartz64ASATA = import ./modules/dt-overlay/quartz64a-sata.nix;
         dtOverlayPCIeFix = import ./modules/dt-overlay/pcie-fix.nix;
         dtOrangePi5B = import ./modules/dt-overlay/rk3588s-orangepi5b.nix;
+        dtOverlayPineTab2 = import ./modules/dt-overlay/pinetab2.nix;
+        bes2600 = import ./modules/bes2600.nix;
       };
     }
     // inputs.utils.lib.eachDefaultSystem (
@@ -244,7 +241,7 @@
 
           uBootNanoPCT6 = uBoot.uBootNanoPCT6;
 
-          bes2600 = bes2600Firmware;
+          bes2600Firmware = bes2600Firmware;
           brcm43456 = brcm43456wifiFirmware;
           brcm43752 = brcm43752pcieFirmware;
         };

--- a/modules/bes2600.nix
+++ b/modules/bes2600.nix
@@ -1,0 +1,17 @@
+{
+  config,
+  pkgs,
+  lib,
+  modulesPath,
+  ...
+}:
+let
+  bes2600Firmware = pkgs.callPackage ../pkgs/bes2600-firmware.nix { };
+in
+{
+  boot.extraModulePackages = [
+    (config.boot.kernelPackages.callPackage ../pkgs/bes2600-kernel-module.nix { })
+  ];
+  boot.kernelModules = [ "bes2600" ];
+  hardware.firmware = [ bes2600Firmware ];
+}

--- a/modules/dt-overlay/pinetab2.nix
+++ b/modules/dt-overlay/pinetab2.nix
@@ -1,0 +1,165 @@
+{
+  config,
+  pkgs,
+  lib,
+  modulesPath,
+  ...
+}:
+{
+  # This is all changes *except*
+  # "arm64: dts: rockchip: pinetab2: Add Bestechnic BES2600 device node"
+  # and
+  # "arm64: dts: rockchip: pinetab2: Change SD card speed to SDR50"
+  # because those remove items, which cannot be done in an overlay.
+  hardware.deviceTree.overlays = [
+    {
+      name = "pinetab2-v2.0";
+      dtsText = ''
+        /dts-v1/;
+        /plugin/;
+
+        #include <dt-bindings/pinctrl/rockchip.h>
+        #include <dt-bindings/gpio/gpio.h>
+        #include <dt-bindings/interrupt-controller/irq.h>
+        #include <dt-bindings/usb/pd.h>
+
+        /* I don't fully understand why this needs to be split up
+           into two nodes and one should use the '&{/}' syntax, but
+           by trial and error this is the variation that works
+           (typec-extcon is created and bes2600 is correctly linked).
+           To review.
+        */
+        / {
+          compatible = "pine64,pinetab2-v2.0";
+
+          aliases {
+            ethernet0 = &bes2600;
+          };
+        };
+
+        &{/} {
+          typec_extcon_bridge: typec-extcon {
+            compatible = "linux,typec-extcon-bridge";
+            usb-role-switch;
+            mode-switch;
+            orientation-switch;
+          };
+        };
+
+        &sdmmc1 {
+          bes2600: bes2600@0 {
+            compatible = "bestechnic,bes2600-sdio";
+            reg = <0>;
+            wakeup-gpios = <&gpio0 RK_PB7 GPIO_ACTIVE_LOW>;
+            host-wakeup-gpios = <&gpio0 RK_PC4 GPIO_ACTIVE_HIGH>;
+          };
+        };
+
+        &vcc_wl {
+          // enable-active-high is not valid for v0.1
+          enable-active-high;
+          gpio = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
+        };
+
+        &rk817 {
+          regulators {
+            vdd_gpu_npu: DCDC_REG2 {
+              regulator-always-on;
+              regulator-boot-on;
+            };
+          };
+        };
+
+        &i2c0 {
+          usbc0: usb-typec@4e {
+            compatible = "hynetek,husb311";
+            reg = <0x4e>;
+            interrupt-parent = <&gpio0>;
+            interrupts = <RK_PC5 IRQ_TYPE_LEVEL_LOW>;
+            pinctrl-names = "default";
+            pinctrl-0 = <&usbcc_int_l>;
+            vbus-supply = <&vbus>;
+
+            connector {
+              compatible = "usb-c-connector";
+              label = "USB-C";
+              data-role = "dual";
+              power-role = "dual";
+              try-power-role = "sink";
+              op-sink-microwatt = <2500000>;
+              sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
+              source-pdos = <PDO_FIXED(5000, 500, PDO_FIXED_USB_COMM)>;
+              mode-switch = <&typec_extcon_bridge>;
+              orientation-switch = <&typec_extcon_bridge>;
+              usb-role-switch = <&typec_extcon_bridge>;
+
+              port {
+                typec_hs_usb_host0_xhci: endpoint {
+                  remote-endpoint = <&usb_host0_xhci_typec_hs>;
+                };
+              };
+            };
+          };
+        };
+
+        &pinctrl {
+          bt {
+            bt_reg_on_h: bt-reg-on-h {
+              rockchip,pins = <0 RK_PC1 RK_FUNC_GPIO &pcfg_pull_none>;
+            };
+
+            bt_wake_host_h: bt-wake-host-h {
+              rockchip,pins = <0 RK_PB5 RK_FUNC_GPIO &pcfg_pull_down>;
+            };
+
+            host_wake_bt_h: host-wake-bt-h {
+              rockchip,pins = <0 RK_PB6 RK_FUNC_GPIO &pcfg_pull_none>;
+            };
+          };
+
+          usb {
+            usbcc_int_l: usbcc-int-l {
+              rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
+            };
+          };
+        };
+
+        &uart1 {
+          pinctrl-0 = <&uart1m0_ctsn>, <&uart1m0_rtsn>, <&uart1m0_xfer>;
+          pinctrl-names = "default";
+          uart-has-rtscts;
+          status = "okay";
+
+          bluetooth {
+            compatible = "bestechnic,bes2600-btuart";
+            interrupts-extended = <&gpio0 RK_PB5 IRQ_TYPE_LEVEL_HIGH>;
+            interrupt-names = "wakeup";
+            wakeup-source;
+
+            pinctrl-names = "default";
+            pinctrl-0 = <&bt_reg_on_h>, <&bt_wake_host_h>, <&host_wake_bt_h>;
+
+            power-gpios = <&gpio0 RK_PC1 GPIO_ACTIVE_HIGH>;
+            wakeup-gpios = <&gpio0 RK_PB6 GPIO_ACTIVE_HIGH>;
+            host-wakeup-gpios = <&gpio0 RK_PB5 GPIO_ACTIVE_HIGH>;
+          };
+        };
+
+        /* OTG port controller */
+        &usb_host0_xhci {
+          extcon = <&typec_extcon_bridge>;
+
+          port {
+            usb_host0_xhci_typec_hs: endpoint {
+              remote-endpoint = <&typec_hs_usb_host0_xhci>;
+            };
+          };
+        };
+
+        &usb2phy0 {
+          extcon = <&typec_extcon_bridge>;
+        };
+      '';
+    }
+  ];
+}

--- a/pkgs/bes2600-firmware.nix
+++ b/pkgs/bes2600-firmware.nix
@@ -23,6 +23,6 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "bes2600 firmware";
     homepage = "https://gitlab.com/pine64-org/bes2600-firmware";
-    license = licenses.unfree;
+    license = licenses.unfreeRedistributableFirmware;
   };
 }

--- a/pkgs/bes2600-kernel-module.nix
+++ b/pkgs/bes2600-kernel-module.nix
@@ -1,0 +1,64 @@
+{
+  fetchFromGitHub,
+  fetchFromGitea,
+  kernel,
+  kernelModuleMakeFlags,
+  stdenv,
+  lib,
+}:
+
+stdenv.mkDerivation rec {
+  name = "bes2600";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "raboof";
+    repo = "bes2600";
+    rev = "028f51d4100eb3be170903ba26f2497b342dd46d";
+    hash = "sha256-kiK31kgQcy+I9dK3J1UNJAIdboHhKkrfwa+2qtU2RdM=";
+  };
+  sourceRoot = "source/bes2600";
+  hardeningDisable = [
+    "pic"
+    "format"
+  ];
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+  makeFlags = kernelModuleMakeFlags ++ [
+    "KERNELRELEASE=${kernel.modDirVersion}"
+    "KERN_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "CONFIG_BES2600=m"
+    "CONFIG_BES2600_5GHZ_SUPPORT=y"
+    "CONFIG_BES2600_DEBUGFS=y"
+    "CONFIG_BES2600_ENABLE_DEVEL_LOGS=y"
+    "CONFIG_BES2600_BTUART=m"
+  ];
+  installPhase = ''
+    runHook preInstall
+    make -C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build \
+      M=$(pwd) \
+      INSTALL_MOD_PATH=$out \
+      $makeFlags \
+      modules_install
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "bes2600 kernel module";
+    /*
+      This is 'just' the bes2600 module from the
+      https://codeberg.org/DanctNIX/linux-pinetab2
+      tree but extracted to a separate repo
+    */
+    homepage = "https://codeberg.org/raboof/bes2600";
+    /*
+      There is some scary license text in txrx_opt.c
+      but that looks like an oversight: it seems
+      questionable if this would be copyrightable at
+      all (given it's mainly interoperability info)
+      and was provided to the community with the goal
+      of using it in the module, but the manufacturer
+      has been MIA in clarifying this explicitly. Make
+      your own judgement.
+    */
+    license = lib.licenses.gpl2Only;
+  };
+}

--- a/pkgs/linux-rockchip.nix
+++ b/pkgs/linux-rockchip.nix
@@ -41,12 +41,146 @@ let
     VIDEO_HANTRO_ROCKCHIP = yes;
   };
   pinetabKernelConfig = with lib.kernel; {
-    BES2600 = module;
-    BES2600_5GHZ_SUPPORT = yes;
-    BES2600_DEBUGFS = yes;
-
     DRM_PANEL_BOE_TH101MB31UIG002_28A = yes;
   };
+  pinetabKernelPatches = [
+    {
+      name = "Enable backlight in defconfig";
+      patch = ./backlight-7.0.patch;
+    }
+    {
+      name = "power: supply: rk817: Fix battery capacity sanity check calculation";
+      patch = (
+        pkgs.fetchpatch {
+          name = "rk817-sanity.patch";
+          url = "https://codeberg.org/DanctNIX/linux-pinetab2/commit/065a04c34f2bea5bde99c79b759d9a7416bfe7f2.patch";
+          hash = "sha256-CU0rzv4M5dUEfCPBAxydhBRH4gY6EaAwiCvhQijP1E0=";
+        }
+      );
+    }
+
+    # The mmc-pwrseq change cannot be done in an overlay
+    {
+      name = "arm64: dts: rockchip: pinetab2: Add Bestechnic BES2600 device node";
+      patch = (
+        pkgs.fetchpatch {
+          name = "sdmmc1-pwrseq.patch";
+          url = "https://codeberg.org/DanctNIX/linux-pinetab2/commit/93f677cdb83fd0e197056efa228da78c0fd8a576.patch";
+          hash = "sha256-bYR/QEB2mgrMW9FXp1/d9k2kWvAfmM3t4nLxcGOG/+Q=";
+        }
+      );
+    }
+    {
+      name = "usb: typec: husb311: Add HUSB311 TCPI driver";
+      patch = (
+        pkgs.fetchpatch {
+          name = "husb311.patch";
+          url = "https://codeberg.org/DanctNIX/linux-pinetab2/commit/be6042fa9bda9cab4da6f35a40083be2c420043b.patch";
+          hash = "sha256-q3LcyGnyj6EkqVGvoz6qPz2nLOb3QJNIQxKuZjJIUzU=";
+        }
+      );
+    }
+    {
+      name = "usb: typec: typec-extcon: Add typec -> extcon bridge driver";
+      patch = (
+        pkgs.fetchpatch {
+          name = "typec-extcon.patch";
+          url = "https://codeberg.org/DanctNIX/linux-pinetab2/commit/cbb637d5f28d43b665fbdb065f4fbd41d99b26b5.patch";
+          hash = "sha256-PZ9iztEHJZR1YFP/uCednNncGMqr94eEcaBvwe7gnfQ=";
+        }
+      );
+    }
+    {
+      name = "usb: typec: typec-extcon: Allow to force reset on each mux change";
+      patch = (
+        pkgs.fetchpatch {
+          name = "typec-extcon-reset.patch";
+          url = "https://codeberg.org/DanctNIX/linux-pinetab2/commit/ba040cc6d03c480e2a0d456c8ffa70267f1e7fc9.patch";
+          hash = "sha256-IDElXsEk8hCz9H8wwkpppI5WC6iz0mjLNgJZSzrnle4=";
+        }
+      );
+    }
+    {
+      name = "phy: phy-rockchip-inno-usb2: Decrease delay between port init and charger detection";
+      patch = (
+        pkgs.fetchpatch {
+          name = "inno-usb2-delay.patch";
+          url = "https://codeberg.org/DanctNIX/linux-pinetab2/commit/f49ea8937e24d70e55487ff9b01cd4e567436954.patch";
+          hash = "sha256-gUh0ECcJB++50uWTqygvPIsAWSDAAg4HTDPPsHVD0mo=";
+        }
+      );
+    }
+    {
+      name = "phy: rockchip-inno-usb2: More robust charger detection extcon updates";
+      patch = (
+        pkgs.fetchpatch {
+          name = "inno-usb2-extcon-updates.patch";
+          url = "https://codeberg.org/DanctNIX/linux-pinetab2/commit/ba156be36961ff68f7dc324b12f32f999bf0d7aa.patch";
+          hash = "sha256-rAAvLpffxcPA8d3+QX5gCVp8grlqza4CdxGOa306PmI=";
+        }
+      );
+    }
+    {
+      name = "phy: rockchip: inno-usb2: Add support for RV1106/RV1103";
+      patch = (
+        pkgs.fetchpatch {
+          name = "inno-usb2-rv11036.patch";
+          url = "https://codeberg.org/DanctNIX/linux-pinetab2/commit/a51393386eb02d204e52c11848a9dcc854fee955.patch";
+          hash = "sha256-ypRgJcgiHY94kDmZZGnJObtOWH6Sq1nKlxqL1Bg7jko=";
+        }
+      );
+    }
+    {
+      name = "phy: rockchip: inno-usb2: Add RK3568 PHY tuning";
+      patch = (
+        pkgs.fetchpatch {
+          name = "inno-usb2-rk3568-phy-tuning.patch";
+          url = "https://codeberg.org/DanctNIX/linux-pinetab2/commit/5edf98f0ee96f79da90f5035e3aa9dac04b6ffe9.patch";
+          hash = "sha256-2roU/7vh46XDnGDTDTXL1ich6q0aL0UzImBN6H4sin4=";
+        }
+      );
+    }
+    {
+      name = "arm64: dts: rockchip: pinetab2: Change SD card speed to SDR50";
+      patch = (
+        pkgs.fetchpatch {
+          name = "sd-card-speed.patch";
+          url = "https://codeberg.org/DanctNIX/linux-pinetab2/commit/1175e9059926724ccf363397611f6fb53925ce0e.patch";
+          hash = "sha256-0e8JQAJRj6hvdsjHqy9EZieVz1NypBGGpbYoZQSlF1c=";
+        }
+      );
+    }
+    {
+      name = "net: bluetooth: Add quirk for broken LE buffer size v2";
+      patch = (
+        pkgs.fetchpatch {
+          name = "bt-quirk-le-buffer.patch";
+          url = "https://codeberg.org/DanctNIX/linux-pinetab2/commit/c3638c132135b290e40bb5303815af0d9b69803e.patch";
+          hash = "sha256-qOSGSkXMvT6MaZRSgjOPiFRLs/kbrRkEcRYWEpyQdI4=";
+        }
+      );
+    }
+    {
+      name = "drm/panel: boe-th101mb31ig002: Prepare the previous controller to LP-11";
+      patch = (
+        pkgs.fetchpatch {
+          name = "boe-th101mb31ig002-lp11.patch";
+          url = "https://codeberg.org/DanctNIX/linux-pinetab2/commit/7398078b7d9fd557b4935c313f26581d3319060e.patch";
+          hash = "sha256-gA+QKzTTsd5L7eT/GRFmjlfKUIIajMgeTDWEUsX3Ayg=";
+        }
+      );
+    }
+    {
+      name = "drm/panel: boe-th101mb31ig002: Longer delay on sleep out mode";
+      patch = (
+        pkgs.fetchpatch {
+          name = "boe-th101mb31ig002-delay-on-sleep-outmode.patch";
+          url = "https://codeberg.org/DanctNIX/linux-pinetab2/commit/120e2e838e3afa35d0159f8f3239e02f2b6c7822.patch";
+          hash = "sha256-gl7eO3pWakfxiJbborFSAs/Jo2O+o1JvIBdNcXtRgoY=";
+        }
+      );
+    }
+  ];
 in
 {
   linux_latest_rockchip_stable = pkgs-stable.linuxKernel.packagesFor (
@@ -83,32 +217,19 @@ in
       }
     );
 
-  linux_7_0_pinetab_unstable =
-    let
-      version = "7.0.6-danctnix1";
-    in
-    pkgs.linuxKernel.packagesFor (
-      pkgs.linuxKernel.kernels.linux_7_0.override {
-        argsOverride = {
-          src = pkgs.fetchFromGitea {
-            domain = "codeberg.org";
-            owner = "DanctNIX";
-            repo = "linux-pinetab2";
-            rev = "v${version}";
-            hash = "sha256-YYcJF5qmCJGsZhB1xLST/ecaPeOR5QGYEuHMqOHxjZ0=";
-          };
-          inherit version;
-          modDirVersion = version;
-        };
-        kernelPatches = [
-          {
-            name = "Enable backlight in defconfig";
-            patch = ./backlight-7.0.patch;
-          }
-        ];
-        structuredExtraConfig = kernelConfig // pinetabKernelConfig;
-      }
-    );
+  linux_7_0_pinetab_stable = pkgs-stable.linuxKernel.packagesFor (
+    pkgs-stable.linuxKernel.kernels.linux_7_0.override {
+      kernelPatches = pinetabKernelPatches;
+      structuredExtraConfig = kernelConfig // pinetabKernelConfig;
+    }
+  );
+
+  linux_7_0_pinetab_unstable = pkgs.linuxKernel.packagesFor (
+    pkgs.linuxKernel.kernels.linux_7_0.override {
+      kernelPatches = pinetabKernelPatches;
+      structuredExtraConfig = kernelConfig // pinetabKernelConfig;
+    }
+  );
 
   linux_6_18_orangepi5b_stable = pkgs-stable.linuxKernel.packagesFor (
     pkgs-stable.linuxKernel.kernels.linux_6_18.override {


### PR DESCRIPTION
Build bes2600 as an out-of-tree module, and the mainline kernel with individual patches instead of a fork.

This mainly shows how relatively close we are to being able to use the mainline kernel.
    
Boots, but modprobing bes2600 gives `(NULL device *): pdata->inited = 0, platform data must be inited at this point`.