### PR TITLE
nixpkgsStable: update to nixos-26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgsStable": {
       "locked": {
-        "lastModified": 1780511130,
-        "narHash": "sha256-2v9lT4ya59Lh1FqPeLnz1MoX9y/wz2huqfe9RtQZITk=",
+        "lastModified": 1780902259,
+        "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "535f3e6942cb1cead3929c604320d3db54b542b9",
+        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Build NixOS images for rockchip based computers";
 
   inputs = {
-    nixpkgsStable.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgsStable.url = "github:NixOS/nixpkgs/nixos-26.05";
     nixpkgsUnstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     utils.url = "github:numtide/flake-utils";
   };

--- a/pkgs/linux-rockchip.nix
+++ b/pkgs/linux-rockchip.nix
@@ -212,6 +212,10 @@ in
             name = "Enable backlight in defconfig";
             patch = ./backlight.patch;
           }
+          {
+            name = "Fix rust lifetime specification";
+            patch = ./patches/linux/6.18/rust-lifetime.patch;
+          }
         ];
         structuredExtraConfig = kernelConfig // pinetabKernelConfig;
       }

--- a/pkgs/patches/linux/6.18/rust-lifetime.patch
+++ b/pkgs/patches/linux/6.18/rust-lifetime.patch
@@ -1,0 +1,31 @@
+diff --git a/rust/kernel/irq/request.rs b/rust/kernel/irq/request.rs
+index b150563fdef8..33d86255f865 100644
+--- a/rust/kernel/irq/request.rs
++++ b/rust/kernel/irq/request.rs
+@@ -261,7 +261,7 @@ pub fn synchronize(&self, dev: &Device<Bound>) -> Result {
+ /// # Safety
+ ///
+ /// This function should be only used as the callback in `request_irq`.
+-unsafe extern "C" fn handle_irq_callback<T: Handler>(_irq: i32, ptr: *mut c_void) -> c_uint {
++unsafe extern "C" fn handle_irq_callback<T: Handler + 'static>(_irq: i32, ptr: *mut c_void) -> c_uint {
+     // SAFETY: `ptr` is a pointer to `Registration<T>` set in `Registration::new`
+     let registration = unsafe { &*(ptr as *const Registration<T>) };
+     // SAFETY: The irq callback is removed before the device is unbound, so the fact that the irq
+@@ -480,7 +480,7 @@ pub fn synchronize(&self, dev: &Device<Bound>) -> Result {
+ /// # Safety
+ ///
+ /// This function should be only used as the callback in `request_threaded_irq`.
+-unsafe extern "C" fn handle_threaded_irq_callback<T: ThreadedHandler>(
++unsafe extern "C" fn handle_threaded_irq_callback<T: ThreadedHandler + 'static>(
+     _irq: i32,
+     ptr: *mut c_void,
+ ) -> c_uint {
+@@ -496,7 +496,7 @@ pub fn synchronize(&self, dev: &Device<Bound>) -> Result {
+ /// # Safety
+ ///
+ /// This function should be only used as the callback in `request_threaded_irq`.
+-unsafe extern "C" fn thread_fn_callback<T: ThreadedHandler>(_irq: i32, ptr: *mut c_void) -> c_uint {
++unsafe extern "C" fn thread_fn_callback<T: ThreadedHandler + 'static>(_irq: i32, ptr: *mut c_void) -> c_uint {
+     // SAFETY: `ptr` is a pointer to `ThreadedRegistration<T>` set in `ThreadedRegistration::new`
+     let registration = unsafe { &*(ptr as *const ThreadedRegistration<T>) };
+     // SAFETY: The irq callback is removed before the device is unbound, so the fact that the irq


### PR DESCRIPTION
Building the .#PineTab2 succeeds, booting the uboot works fine (including video and keyboard) and the kernel boots up to the bash prompt. Didn't test further, let's see what CI turns up.