### PR TITLE
Added radxa rock 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Applies device tree overlay for OrangePI5B
 | [Pinebook Pro][]     | PinebookPro     | Untested         |
 | Orange Pi CM4        | OrangePiCM4     | Untested         |
 | Orange Pi 5B         | OrangePi5B      | Needs New Kernel |
+| Radxa Rock 2         | RadxaRock2      | Tested & Works   |
 | Radxa CM3/CM3 I/O    | RadxaCM3IO      | Untested         |
 | [Radxa Rock 4][]     | RadxaRock4      | Tested & Works   |
 | [Radxa Rock4 SE][]   | RadxaRock4SE    | Tested & Works   |

--- a/flake.nix
+++ b/flake.nix
@@ -159,6 +159,14 @@
               self.nixosModules.dtOrangePi5B
             ];
           };
+          "RadxaRock2" = {
+            uBoot = uBoot.uBootRadxaRock2;
+            kernel = kernel.linux_6_1_radxa_rk2312_stable;
+            extraModules = [
+              noZFS
+              self.nixosModules.radxaRk2312DisableModules
+            ];
+          };
           "RadxaCM3IO" = {
             uBoot = uBoot.uBootRadxaCM3IO;
             kernel = kernel.linux_latest_rockchip_stable;
@@ -222,12 +230,14 @@
     {
       nixosModules = {
         inherit noZFS;
+        radxaRk2312DisableModules = import ./modules/radxa-rk2312-disable-modules.nix;
         sdImageRockchipInstaller = import ./modules/sd-card/sd-image-rockchip-installer.nix;
         sdImageRockchip = import ./modules/sd-card/sd-image-rockchip.nix;
         dtOverlayQuartz64ASATA = import ./modules/dt-overlay/quartz64a-sata.nix;
         dtOverlayPCIeFix = import ./modules/dt-overlay/pcie-fix.nix;
         dtOrangePi5B = import ./modules/dt-overlay/rk3588s-orangepi5b.nix;
         dtOverlayPineTab2 = import ./modules/dt-overlay/pinetab2.nix;
+        dtOverlayRock2AEnablePCIe = import ./modules/dt-overlay/rock-2a-enable-pcie.nix;
         bes2600 = import ./modules/bes2600.nix;
       };
     }
@@ -236,6 +246,9 @@
         legacyPackages = {
           kernel_linux_latest_rockchip_stable = kernel.linux_latest_rockchip_stable;
           kernel_linux_latest_rockchip_unstable = kernel.linux_latest_rockchip_unstable;
+
+          kernel_linux_6_1_radxa_rk2312_stable = kernel.linux_6_1_radxa_rk2312_stable;
+          kernel_linux_6_1_radxa_rk2312_unstable = kernel.linux_6_1_radxa_rk2312_unstable;
 
           kernel_linux_6_18_pinetab_stable = kernel.linux_6_18_pinetab_stable;
           kernel_linux_7_0_pinetab_unstable = kernel.linux_7_0_pinetab_unstable;
@@ -260,6 +273,7 @@
           uBootOrangePi3B = uBoot.uBootOrangePi3B;
           uBootOrangePi5B = uBoot.uBootOrangePi5B;
 
+          uBootRadxaRock2 = uBoot.uBootRadxaRock2;
           uBootRadxaCM3IO = uBoot.uBootRadxaCM3IO;
           uBootRadxaRock4 = uBoot.uBootRadxaRock4;
           uBootRadxaRock4SE = uBoot.uBootRadxaRock4SE;

--- a/modules/dt-overlay/rock-2a-enable-pcie.nix
+++ b/modules/dt-overlay/rock-2a-enable-pcie.nix
@@ -1,0 +1,65 @@
+{
+  config,
+  pkgs,
+  lib,
+  modulesPath,
+  ...
+}:
+{
+  hardware.deviceTree.overlays = [
+    {
+      name = "rock-2a-enable-pcie";
+      dtsText = ''
+        /dts-v1/;
+        /plugin/;
+
+        #include <dt-bindings/gpio/gpio.h>
+        #include <dt-bindings/pinctrl/rockchip.h>
+
+        / {
+          compatible = "radxa,rock-2a";
+          
+          metadata {
+            title = "Enable PCIe";
+            compatible = "radxa,rock-2a";
+            category = "misc";
+            exclusive = "pcie2x1";
+            description = "After enabling PCIe, the USB OTG port supports up to high speed";
+          };
+        };
+
+        &{/} {
+          vcc3v3_pcie: vcc3v3-pcie {
+            compatible = "regulator-fixed";
+            regulator-name = "vcc3v3_pcie";
+            regulator-min-microvolt = <3300000>;
+            regulator-max-microvolt = <3300000>;
+            startup-delay-us = <5000>;
+            enable-active-high;
+            gpio = <&gpio1 RK_PA4 GPIO_ACTIVE_HIGH>;
+            vin-supply = <&vcc5v0_sys>;
+          };
+        };
+
+        &pcie_usb_selection {
+          enable-active-high;
+          gpio = <&gpio4 RK_PA5 GPIO_ACTIVE_HIGH>;
+        };
+
+        &usbdrd_dwc3 {
+          phys = <&u2phy_otg>;
+          phy-names = "usb2-phy";
+          maximum-speed = "high-speed";
+          snps,dis_u2_susphy_quirk;
+          snps,usb2-lpm-disable;
+        };
+
+        &pcie2x1 {
+          reset-gpios = <&gpio1 RK_PA2 GPIO_ACTIVE_HIGH>;
+          vpcie3v3-supply = <&vcc3v3_pcie>;
+          status = "okay";
+        };
+      '';
+    }
+  ];
+}

--- a/modules/radxa-rk2312-disable-modules.nix
+++ b/modules/radxa-rk2312-disable-modules.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  ...
+}:
+{
+  boot.initrd.availableKernelModules = {
+    "ata_piix" = lib.mkForce false;
+
+    "sata_inic162x" = lib.mkForce false;
+    "sata_nv" = lib.mkForce false;
+    "sata_promise" = lib.mkForce false;
+    "sata_qstor" = lib.mkForce false;
+    "sata_sil" = lib.mkForce false;
+    "sata_sil24" = lib.mkForce false;
+    "sata_sis" = lib.mkForce false;
+    "sata_svw" = lib.mkForce false;
+    "sata_sx4" = lib.mkForce false;
+    "sata_uli" = lib.mkForce false;
+    "sata_via" = lib.mkForce false;
+    "sata_vsc" = lib.mkForce false;
+
+    "pata_ali" = lib.mkForce false;
+    "pata_amd" = lib.mkForce false;
+    "pata_artop" = lib.mkForce false;
+    "pata_atiixp" = lib.mkForce false;
+    "pata_efar" = lib.mkForce false;
+    "pata_hpt366" = lib.mkForce false;
+    "pata_hpt37x" = lib.mkForce false;
+    "pata_hpt3x2n" = lib.mkForce false;
+    "pata_hpt3x3" = lib.mkForce false;
+    "pata_it8213" = lib.mkForce false;
+    "pata_it821x" = lib.mkForce false;
+    "pata_jmicron" = lib.mkForce false;
+    "pata_marvell" = lib.mkForce false;
+    "pata_mpiix" = lib.mkForce false;
+    "pata_netcell" = lib.mkForce false;
+    "pata_ns87410" = lib.mkForce false;
+    "pata_oldpiix" = lib.mkForce false;
+    "pata_pcmcia" = lib.mkForce false;
+    "pata_pdc2027x" = lib.mkForce false;
+    "pata_rz1000" = lib.mkForce false;
+    "pata_serverworks" = lib.mkForce false;
+    "pata_sil680" = lib.mkForce false;
+    "pata_sis" = lib.mkForce false;
+    "pata_sl82c105" = lib.mkForce false;
+    "pata_triflex" = lib.mkForce false;
+    "pata_via" = lib.mkForce false;
+    "pata_qdi" = lib.mkForce false;
+    "pata_winbond" = lib.mkForce false;
+
+    "3w-9xxx" = lib.mkForce false;
+    "3w-xxxx" = lib.mkForce false;
+    "aic79xx" = lib.mkForce false;
+    "aic7xxx" = lib.mkForce false;
+    "arcmsr" = lib.mkForce false;
+    "hpsa" = lib.mkForce false;
+
+    "sdhci_pci" = lib.mkForce false;
+
+    "ohci1394" = lib.mkForce false;
+    "sbp2" = lib.mkForce false;
+
+    "virtio_net" = lib.mkForce false;
+    "virtio_pci" = lib.mkForce false;
+    "virtio_mmio" = lib.mkForce false;
+    "virtio_blk" = lib.mkForce false;
+    "virtio_scsi" = lib.mkForce false;
+    "virtio_balloon" = lib.mkForce false;
+    "virtio_console" = lib.mkForce false;
+
+    "mptspi" = lib.mkForce false;
+    "vmxnet3" = lib.mkForce false;
+
+    "sun4i-drm" = lib.mkForce false;
+    "sun8i-mixer" = lib.mkForce false;
+
+    "pwm-sun4i" = lib.mkForce false;
+
+    "vc4" = lib.mkForce false;
+
+    "pcie-brcmstb" = lib.mkForce false;
+
+    "rockchipdrm" = lib.mkForce false;
+    "rockchip-rga" = lib.mkForce false;
+    "pcie-rockchip-host" = lib.mkForce false;
+
+    "axp20x-ac-power" = lib.mkForce false;
+    "axp20x-battery" = lib.mkForce false;
+    "pinctrl-axp209" = lib.mkForce false;
+    "mp8859" = lib.mkForce false;
+
+    "xhci-pci-renesas" = lib.mkForce false;
+
+    "reset-raspberrypi" = lib.mkForce false;
+
+    "analogix-dp" = lib.mkForce false;
+    "analogix-anx6345" = lib.mkForce false;
+
+    "uhci_hcd" = lib.mkForce false;
+    "ohci_pci" = lib.mkForce false;
+
+    "hid_lenovo" = lib.mkForce false;
+    "hid_apple" = lib.mkForce false;
+    "hid_roccat" = lib.mkForce false;
+    "hid_logitech_hidpp" = lib.mkForce false;
+    "hid_logitech_dj" = lib.mkForce false;
+    "hid_microsoft" = lib.mkForce false;
+    "hid_cherry" = lib.mkForce false;
+    "hid_corsair" = lib.mkForce false;
+
+    "tpm-crb" = lib.mkForce false;
+    "tpm-tis" = lib.mkForce false;
+  };
+}

--- a/pkgs/linux-rockchip.nix
+++ b/pkgs/linux-rockchip.nix
@@ -2,6 +2,7 @@
   pkgs,
   pkgs-stable,
   lib,
+  fetchFromGitHub,
 }:
 
 let
@@ -181,6 +182,25 @@ let
       );
     }
   ];
+  radxaRk2312BuildArgs = {
+    version = "6.1.43-26-rk2312";
+    modDirVersion = "6.1.43";
+    src = fetchFromGitHub {
+      owner = "radxa";
+      repo = "kernel";
+      # branch linux-6.1-stan-rkr1
+      rev = "ba75427f384faf9e1246fd2aeaacffae115ba88d";
+      hash = "sha256-PujHYvCuPwCMk9Yvou4Z2z51eJ6eyEeqpEs6ZYvQ3o0=";
+    };
+    extraMakeFlags = [
+      "KCFLAGS+=-Wno-error=enum-int-mismatch"
+      "KCFLAGS+=-Wno-error=calloc-transposed-args"
+      "KCFLAGS+=-Wno-error=incompatible-pointer-types"
+    ];
+    defconfig = "rockchip_linux_defconfig";
+    ignoreConfigErrors = true;
+    autoModules = false;
+  };
 in
 {
   linux_latest_rockchip_stable = pkgs-stable.linuxKernel.packagesFor (
@@ -188,6 +208,13 @@ in
   );
   linux_latest_rockchip_unstable = pkgs.linuxKernel.packagesFor (
     pkgs.linuxKernel.kernels.linux_latest.override { structuredExtraConfig = kernelConfig; }
+  );
+
+  linux_6_1_radxa_rk2312_stable = pkgs-stable.linuxKernel.packagesFor (
+    pkgs-stable.buildLinux radxaRk2312BuildArgs
+  );
+  linux_6_1_radxa_rk2312_unstable = pkgs.linuxKernel.packagesFor (
+    pkgs.buildLinux radxaRk2312BuildArgs
   );
 
   linux_6_18_pinetab_stable =

--- a/pkgs/uboot-rockchip.nix
+++ b/pkgs/uboot-rockchip.nix
@@ -64,6 +64,31 @@ let
       inherit defconfig;
       BL31 = "${pkgs.armTrustedFirmwareRK3399}/bl31.elf";
     };
+  buildRK3528UBoot =
+    defconfig:
+    let
+      rkbin = pkgs-stable.fetchFromGitHub {
+        owner = "rockchip-linux";
+        repo = "rkbin";
+        rev = "74213af1e952c4683d2e35952507133b61394862";
+        sha256 = "gNCZwJd9pjisk6vmvtRNyGSBFfAYOADTa5Nd6Zk+qEk=";
+      };
+    in
+    pkgs-stable.buildUBoot {
+      inherit defconfig;
+
+      filesToInstall = [ "u-boot-rockchip.bin" ];
+
+      env = {
+        BL31 = (rkbin + "/bin/rk35/rk3528_bl31_v1.20.elf");
+        ROCKCHIP_TPL = (rkbin + "/bin/rk35/rk3528_ddr_1056MHz_v1.11.bin");
+      };
+
+      extraMeta = {
+        platforms = [ "aarch64-linux" ];
+        license = lib.licenses.unfreeRedistributableFirmware;
+      };
+    };
   buildRK3566UBoot =
     {
       defconfig,
@@ -182,6 +207,7 @@ in
   uBootOrangePiCM4 = buildRK3566UBoot { defconfig = "orangepi-3b-rk3566_defconfig"; };
   uBootOrangePi3B = buildRK3566UBoot { defconfig = "orangepi-3b-rk3566_defconfig"; };
   uBootOrangePi5B = buildRK3588UBoot "orangepi-5b-rk3588s_defconfig";
+  uBootRadxaRock2 = buildRK3528UBoot "rock-2-rk3528_defconfig";
   uBootRadxaCM3IO = buildRK3566UBoot {
     defconfig = "radxa-cm3-io-rk3566_defconfig";
     spi = false;


### PR DESCRIPTION
Hi! This PR adds support for the older Radxa Rock 2. I have been running this for about a month on my Radxa Rock 2A, and I'm now confident enough to upstream it.

So here is a breakdown of what I've done and why:
- I've added support for building U-Boot for the RK3528.
- I've added special overlays for enabling the PCIE (also tested with my setup), which was taken from [here](https://github.com/radxa-pkg/radxa-overlays).
  - There are other useful overlays, such as the one for the POE hat, but I do not have it and cannot test it properly, also it seems like a niche use case.
- I've added support for compiling and using radxa own kernel, which was the major pain point.
  - This was needed due to fact that radxa overlays DO NOT apply on mainline kernels, due to different device tree.
  - I could have ported the device tree to a mainline kernel but their fork contains other patches and I fear that the device tree is not the only thing needed to make this board work.
  - Compiling this kernel is awful, it contains a mishmash of different kernel versions and features, so many drivers do not compile (for example the AMD GPU driver). This is due to radxa half backporting newer kernel features and never testing outside the default kernel configuration. 
  -  I tried disabling just the modules that do not compile but given the amount of random compilation failures I do not trust most of the codebase to be working "as is", so I think that using the default config (the same used by their Debian based distribution) is the safest option.
  - Since this kernel is built with `autoModules = false` most of the kernel modules expected by the installer are not present. For that reason there is a special `radxa-rk2312-disable-modules` which disables all of the modules that would normally be included by the installer, but are not present in the radxa kernel.
  - While testing this board I've also enabled wireguard and btrfs support, so we could add those modules to the kernel configuration since I've used them and can confirm that they work as expected.