### PR TITLE
fix: OrangePi CM4

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -139,7 +139,7 @@
           };
           "OrangePiCM4" = {
             uBoot = uBoot.uBootOrangePiCM4;
-            kernel = kernel.linux_6_17_rockchip_stable;
+            kernel = kernel.linux_latest_rockchip_stable;
             extraModules = [ noZFS ];
           };
           "OrangePi3B" = {

--- a/flake.nix
+++ b/flake.nix
@@ -140,7 +140,10 @@
           "OrangePiCM4" = {
             uBoot = uBoot.uBootOrangePiCM4;
             kernel = kernel.linux_latest_rockchip_stable;
-            extraModules = [ noZFS ];
+            extraModules = [
+              noZFS
+              { hardware.deviceTree.name = "rockchip/rk3566-orangepi-3b-v2.1.dtb"; }
+            ];
           };
           "OrangePi3B" = {
             uBoot = uBoot.uBootOrangePi3B;


### PR DESCRIPTION
- #65 switched to using "latest" kernels, but opi CM4's `linux_6_17_rockchip_stable` kernel does not exists, this PR uses `linux_latest_rockchip_stable` as opi 3B does.
- mainline kernel does not have a `rk3566-orangepi-cm4.dtb` so u-boot cannot boot into kernel, this PR uses `rk3566-orangepi-3b-v2.1.dtb` explicitly (according to vendor kernel https://github.com/orangepi-xunlong/linux-orangepi/commit/122b41d84d018af909a766e48f3f90cbea9868e0, with the official baseboard, cm4 should be nearly identical to 3b).

Built on x86_64 and booted on a CM4 from both sdcard/eMMC. My CM4 does not have a SPI flash so I cannot test boot from NVMe.

GPIO/USB/ethernet/NVMe SSD works fine.

<img width="1467" height="703" alt="image" src="https://github.com/user-attachments/assets/c42d3762-9c20-47aa-b31b-c5f4453c3b34" />