### PR TITLE
fix: build OrangePiCM4

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -139,7 +139,7 @@
           };
           "OrangePiCM4" = {
             uBoot = uBoot.uBootOrangePiCM4;
-            kernel = kernel.linux_6_17_rockchip_stable;
+            kernel = kernel.linux_latest_rockchip_stable;
             extraModules = [ noZFS ];
           };
           "OrangePi3B" = {

--- a/pkgs/binman-resources.patch
+++ b/pkgs/binman-resources.patch
@@ -1,0 +1,71 @@
+(Patch from https://lists.denx.de/pipermail/u-boot/2024-July/559077.html)
+
+
+pkg_resources is deprecated long ago and being removed in python 3.12.
+
+Reimplement functions with importlib.resources.
+
+Link: https://docs.python.org/3/library/importlib.resources.html
+Signed-off-by: Jiaxun Yang <jiaxun.yang at flygoat.com>
+---
+ tools/binman/control.py | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/tools/binman/control.py b/tools/binman/control.py
+index 2f00279232b8..5549b0ad2185 100644
+--- a/tools/binman/control.py
++++ b/tools/binman/control.py
+@@ -8,12 +8,11 @@
+ from collections import OrderedDict
+ import glob
+ try:
+-    import importlib.resources
+-except ImportError:  # pragma: no cover
++    from importlib import resources
++except ImportError:
+     # for Python 3.6
+-    import importlib_resources
++    import importlib_resources as resources
+ import os
+-import pkg_resources
+ import re
+
+ import sys
+@@ -96,12 +95,12 @@ def _ReadMissingBlobHelp():
+             msg = ''
+         return tag, msg
+
+-    my_data = pkg_resources.resource_string(__name__, 'missing-blob-help')
++    my_data = resources.files(__package__).joinpath('missing-blob-help').read_text()
+     re_tag = re.compile('^([-a-z0-9]+):$')
+     result = {}
+     tag = None
+     msg = ''
+-    for line in my_data.decode('utf-8').splitlines():
++    for line in my_data.splitlines():
+         if not line.startswith('#'):
+             m_tag = re_tag.match(line)
+             if m_tag:
+@@ -151,8 +150,9 @@ def GetEntryModules(include_testing=True):
+     Returns:
+         Set of paths to entry class filenames
+     """
+-    glob_list = pkg_resources.resource_listdir(__name__, 'etype')
+-    glob_list = [fname for fname in glob_list if fname.endswith('.py')]
++    directory = resources.files("binman.etype")
++    glob_list = [entry.name for entry in directory.iterdir()
++                 if entry.name.endswith('.py')]
+     return set([os.path.splitext(os.path.basename(item))[0]
+                 for item in glob_list
+                 if include_testing or '_testing' not in item])
+@@ -735,7 +735,7 @@ def Binman(args):
+     global state
+
+     if args.full_help:
+-        with importlib.resources.path('binman', 'README.rst') as readme:
++        with resources.path('binman', 'README.rst') as readme:
+             tools.print_full_help(str(readme))
+         return 0
+
+-- 
+2.45.2

--- a/pkgs/uboot-rockchip.nix
+++ b/pkgs/uboot-rockchip.nix
@@ -32,6 +32,21 @@ let
         "u-boot-rockchip.bin"
         "u-boot-rockchip-spi.bin"
       ];
+      nativeBuildInputs = [
+        buildPackages.bc
+        buildPackages.bison
+        buildPackages.flex
+        buildPackages.openssl
+        buildPackages.installShellFiles
+        buildPackages.perl
+        buildPackages.which
+        buildPackages.swig
+        (buildPackages.python3.withPackages (ps: [
+          ps.setuptools
+          ps.libfdt
+          ps.pyelftools
+        ]))
+      ];
 
       extraPatches = [ ./ramdisk_addr_r.patch ] ++ extraPatches;
       extraConfiG = [
@@ -86,6 +101,21 @@ let
     in
     buildUBoot {
       inherit defconfig src version;
+      nativeBuildInputs = [
+        buildPackages.bc
+        buildPackages.bison
+        buildPackages.flex
+        buildPackages.openssl
+        buildPackages.installShellFiles
+        buildPackages.perl
+        buildPackages.which
+        buildPackages.swig
+        (buildPackages.python3.withPackages (ps: [
+          ps.setuptools
+          ps.libfdt
+          ps.pyelftools
+        ]))
+      ];
       filesToInstall =
         if spi then
           [
@@ -95,6 +125,7 @@ let
         else
           [ "u-boot-rockchip.bin" ];
       extraPatches = [
+        ./binman-resources.patch
         (fetchpatch {
           name = "quartz64.patch";
           url = "https://github.com/Kwiboo/u-boot-rockchip/compare/25049ad560826f7dc1c4740883b0016014a59789...830cfcfdf54a1f08a3ca7fc17e69b4bc18cece50.diff";


### PR DESCRIPTION
## Summary
Fix OrangePiCM4 image builds by moving it to the current Rockchip stable kernel and restoring the U-Boot host build inputs it needs.

## Changes
- switch `OrangePiCM4` from the missing `kernel.linux_6_17_rockchip_stable` to `kernel.linux_latest_rockchip_stable`
- add the upstream `binman-resources.patch` so U-Boot no longer depends on `pkg_resources`
- add the standard host tools U-Boot uses during its build (`bc`, `bison`, `flex`, `openssl`, `perl`, `swig`, `which`, and Python packages)

## Notes
- This fixes the evaluation failure and the `binman` runtime error seen while building `OrangePiCM4`.
